### PR TITLE
Implemented youtube's (start|end)Seconds API

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1665,7 +1665,7 @@
                         };
                         plyr.media.duration = instance.getDuration();
                         plyr.media.paused = true;
-                        plyr.media.currentTime = plyr.start;
+                        plyr.media.currentTime = start;
                         plyr.media.muted = instance.isMuted();
 
                         // Set title


### PR DESCRIPTION
This allows videos to specify custom start and end points within the video
### Link to related issue (if applicable)

This should resolve #361
### Sumary of proposed changes
- New `data` attributes `data-start` and `data-end` specify the start and end points in the video
- Since YouTube's `playerVars`' [`start`](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5#start) and [`end`](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5#end) fields don't work, use [`cueVideoById`](https://developers.google.com/youtube/iframe_api_reference#cueVideoById) instead
### Task list
- [ ] Tested on [supported browsers](https://github.com/Selz/plyr#browser-support)
- [ ] Gulp build completed 
