### PR TITLE
[bugfix] target is null exception

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2850,10 +2850,12 @@
                     target = plyr.buttons[play ? 'pause' : 'play'];
 
                 // Get the last play button to account for the large play button
-                if (target && target.length > 1) {
-                    target = target[target.length - 1];
-                } else {
-                    target = target[0];
+                if (target) {
+                    if (target.length > 1) {
+                        target = target[target.length - 1];
+                    } else {
+                        target = target[0];
+                    }
                 }
 
                 // Setup focus and tab focus


### PR DESCRIPTION
## Link to related issue (if applicable)

### Sumary of proposed changes

when using 'play-large' without a 'play' button, the statement target = target[0]; caused an error. So it is necessary to first check the value of target before accessing [0]

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed