### PR TITLE
Enable start/stop toggle on whole element

### DIFF
--- a/src/less/plyr.less
+++ b/src/less/plyr.less
@@ -269,6 +269,7 @@
     line-height: 1;
     text-align: center;
     pointer-events: none;
+    
     & > * {
         pointer-events: all;
     }

--- a/src/less/plyr.less
+++ b/src/less/plyr.less
@@ -268,6 +268,10 @@
     align-items: center;
     line-height: 1;
     text-align: center;
+    pointer-events: none;
+    & > * {
+        pointer-events: all;
+    }
 
     // Spacing
     > button,

--- a/src/scss/plyr.scss
+++ b/src/scss/plyr.scss
@@ -268,6 +268,7 @@
     line-height: 1;
     text-align: center;
     pointer-events: none;
+    
     & > * {
         pointer-events: all;
     }

--- a/src/scss/plyr.scss
+++ b/src/scss/plyr.scss
@@ -267,7 +267,11 @@
     align-items: center;
     line-height: 1;
     text-align: center;
-
+    pointer-events: none;
+    & > * {
+        pointer-events: all;
+    }
+    
     // Spacing
     > button,
     .plyr__progress,


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/587

### Sumary of proposed changes
Disable pointer-events on `.plyr__controls` and add the events to all children so the whole element can be clicked. This will also solve the none-clickable hidden control area when controls is hidden.

### Task list
Not tested, no build, sorz
- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed