### PR TITLE
Fix 'TypeError: Cannot read property 'kind' of null' in captions feat…

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2448,7 +2448,7 @@
                 });
 
                 // Check if suported kind
-                var supported = utils.inArray(['captions', 'subtitles'], player.captions.currentTrack.kind);
+                var supported = utils.inArray(['captions', 'subtitles'], player.captions.currentTrack && player.captions.currentTrack.kind);
 
                 if (utils.is.track(player.captions.currentTrack) && supported) {
                     utils.on(player.captions.currentTrack, 'cuechange', setActiveCue);


### PR DESCRIPTION
`player.captions.currentTrack` is null in Chrome 61 when there are no captions, so the caption `supported` detection triggers an error (the detection still actually works though).

![screen shot 2017-09-27 at 00 33 09](https://user-images.githubusercontent.com/515120/30887374-7a01ef4c-a31b-11e7-9f0e-f5183761a017.png)

I didn't create any issue since it's in the "There will be bugs" a.k.a. develop branch