### PR TITLE
Prevent buttons from submitting form (v3)

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1511,6 +1511,10 @@
                 attributes = {};
             }
 
+            if (!('type' in attributes)) {
+                attributes.type = 'button';
+            }
+
             if ('class' in attributes) {
                 if (attributes.class.indexOf(player.config.classNames.control) === -1) {
                     attributes.class += ' ' + player.config.classNames.control;


### PR DESCRIPTION
In the v3/develop branch, all buttons will submit the form they're in. This is due to having the default button "type" (submit) rather than "button". 

I suspect this is related to the new settings menu, which is wrapped in a form, and might benefit from it's buttons submitting?

This PR sets the type to "button" unless you specify type as an attribute with `createButton()`. This may be over-complicating things if @sampotts doesn't intend to support/use submitting buttons. The settings menu still works in my tests (I'm only using it with captions though).