### PR TITLE
Avoid errors when initiating plyr without settings (v3)

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1948,7 +1948,9 @@
             player.elements.controls = controls;
 
             //setLoopMenu();
-            setSpeedMenu();
+            if (utils.inArray(player.config.controls, 'settings') && utils.inArray(player.config.settings, 'speed')) {
+                setSpeedMenu();
+            }
 
             return controls;
         }
@@ -2101,6 +2103,7 @@
 
         // Update the selected setting
         function updateSetting(setting, list) {
+            var pane = player.elements.settings.panes[setting];
             var value = null;
 
             switch (setting) {
@@ -2131,11 +2134,11 @@
 
             // Get the list if we need to
             if (!utils.is.htmlElement(list)) {
-                list = player.elements.settings.panes[setting].querySelector('ul');
+                list = pane && pane.querySelector('ul');
             }
 
             // Find the radio option
-            var target = list.querySelector('input[value="' + value + '"]');
+            var target = list && list.querySelector('input[value="' + value + '"]');
 
             if (!utils.is.htmlElement(target)) {
                 return;
@@ -2367,7 +2370,9 @@
                 player.captions.tracks = null;
 
                 // Clear menu and hide
-                setCaptionsMenu();
+                if (utils.inArray(player.config.controls, 'settings') && utils.inArray(player.config.settings, 'captions')) {
+                    setCaptionsMenu();
+                }
 
                 return;
             }
@@ -2463,7 +2468,9 @@
             }
 
             // Set available languages in list
-            setCaptionsMenu();
+            if (utils.inArray(player.config.controls, 'settings') && utils.inArray(player.config.settings, 'captions')) {
+                setCaptionsMenu();
+            }
         }
 
         // Get current selected caption language
@@ -3050,7 +3057,9 @@
                         player.media.muted = instance.isMuted();
 
                         // Get available speeds
-                        setSpeedMenu(instance.getAvailablePlaybackRates(), instance.getPlaybackRate());
+                        if (utils.inArray(player.config.controls, 'settings') && utils.inArray(player.config.settings, 'speed')) {
+                            setSpeedMenu(instance.getAvailablePlaybackRates(), instance.getPlaybackRate());
+                        }
 
                         // Set title
                         player.config.title = instance.getVideoData().title;
@@ -3376,10 +3385,10 @@
         function toggleMenu(event) {
             var form = player.elements.settings.form;
             var button = player.elements.buttons.settings;
-            var show = utils.is.boolean(event) ? event : form.getAttribute('aria-hidden') === 'true';
+            var show = utils.is.boolean(event) ? event : (form && form.getAttribute('aria-hidden') === 'true');
 
             if (utils.is.event(event)) {
-                var isMenuItem = form.contains(event.target);
+                var isMenuItem = form && form.contains(event.target);
                 var isButton = event.target === player.elements.buttons.settings;
 
                 // If the click was inside the form or if the click
@@ -3396,13 +3405,16 @@
             }
 
             // Set form and button attributes
-            form.setAttribute('aria-hidden', !show);
-            button.setAttribute('aria-expanded', show);
-
-            if (show) {
-                form.removeAttribute('tabindex');
-            } else {
-                form.setAttribute('tabindex', -1);
+            if (button) {
+                button.setAttribute('aria-expanded', show);
+            }
+            if (form) {
+                form.setAttribute('aria-hidden', !show);
+                if (show) {
+                    form.removeAttribute('tabindex');
+                } else {
+                    form.setAttribute('tabindex', -1);
+                }
             }
         }
 
@@ -5579,7 +5591,9 @@
                 // Trigger event and close menu
                 if (toggled) {
                     player.core.trigger(player.media, 'controlshidden');
-                    player.core.toggleMenu(false);
+                    if (utils.inArray(player.config.controls, 'settings') && !utils.is.empty(player.config.settings)) {
+                        player.core.toggleMenu(false);
+                    }
                 }
             }, delay);
         }


### PR DESCRIPTION
Plyr 3 (develop branch) won't work if you initiate without the "settings"-control:

Example:
```js
new Plyr(video, {controls: ['play', 'progress']})
```

Will result in multiple errors trying to access properties of `undefined`.

This PR checks that `setCaptionsMenu()` and `setSpeedMenu()` aren't run unless settings are enabled and those sections are enabled.
It also checks that `form` exists before trying to access properties and ensures `updateSetting` won't break if the pane doesn't exist.