### PR TITLE
Removing role="presentation" that shows up an error in W3C validation

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -822,7 +822,7 @@
                 html.push('<span class="plyr__progress">',
                     '<label for="seek{id}" class="plyr__sr-only">Seek</label>',
                     '<input id="seek{id}" class="plyr__progress--seek" type="range" min="0" max="100" step="0.1" value="0" data-plyr="seek">',
-                    '<progress class="plyr__progress--played" max="100" value="0" role="presentation"></progress>',
+                    '<progress class="plyr__progress--played" max="100" value="0"></progress>',
                     '<progress class="plyr__progress--buffer" max="100" value="0">',
                         '<span>0</span>% ' + config.i18n.buffered,
                     '</progress>');
@@ -873,7 +873,7 @@
                     '<span class="plyr__volume">',
                         '<label for="volume{id}" class="plyr__sr-only">' + config.i18n.volume + '</label>',
                         '<input id="volume{id}" class="plyr__volume--input" type="range" min="' + config.volumeMin + '" max="' + config.volumeMax + '" value="' + config.volume + '" data-plyr="volume">',
-                        '<progress class="plyr__volume--display" max="' + config.volumeMax + '" value="' + config.volumeMin + '" role="presentation"></progress>',
+                        '<progress class="plyr__volume--display" max="' + config.volumeMax + '" value="' + config.volumeMin + '"></progress>',
                     '</span>'
                 );
             }


### PR DESCRIPTION
### Link to related issue
[#516](https://github.com/sampotts/plyr/issues/516)

### Sumary of proposed changes
Removing the attribute role="presentation" that shows up an error in W3C validation.

### Task list

- [x] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Tested on W3C Validator
- [x] Gulp build completed