### PR TITLE
Restore volume stepping via key up/down

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -4100,12 +4100,12 @@
 
                         case 38:
                             // Arrow up
-                            player.increaseVolume();
+                            player.increaseVolume(0.1);
                             break;
 
                         case 40:
                             // Arrow down
-                            player.decreaseVolume();
+                            player.decreaseVolume(0.1);
                             break;
 
                         case 77:


### PR DESCRIPTION
Restores v2's behavior with 10 steps when changing volume with up/down keys (currently in develop  it jumps directly to max/min).

