### PR TITLE
Allow Plyr.setup event listeners to be set up as separate event listeners

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -472,13 +472,21 @@
 
     // Bind along with custom handler
     function _proxyListener(element, eventName, userListener, defaultListener, useCapture) {
+        if(userListener) {
+            // Register this before defaultListener
+            _on(
+                element,
+                eventName,
+                function(event) {
+                    userListener.apply(element, [event]);
+                },
+                useCapture
+            );
+        }
         _on(
             element,
             eventName,
             function(event) {
-                if (userListener) {
-                    userListener.apply(element, [event]);
-                }
                 defaultListener.apply(element, [event]);
             },
             useCapture


### PR DESCRIPTION
This allows the setup listeners to do things like
preventDefault()/stopImmediatePropagation() and have them work

### Link to related issue (if applicable)
There is an [issue comment](https://github.com/sampotts/plyr/pull/141#issuecomment-341026257)

### Sumary of proposed changes
Earlier, if a `listener` was specified during `Plyr.setup()`, we set up one event handler with both the provided listener (`userListener`) as well as the `defaultListener`.

Now, each of these is attached as a separate event listener (`userListener` being attached first).
This ensures that `preventDefault()`/`stopImmediatePropagation()` are handled correctly.

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed