### PR TITLE
double click player to toggle fullscreen

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2229,9 +2229,11 @@
 
         // Toggle fullscreen
         function _toggleFullscreen(event) {
+            // We don't allow fullscreen on audio player
             if (plyr.type === 'audio') {
               return
             }
+
             // Check for native support
             var nativeSupport = fullscreen.supportsFullScreen;
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2229,6 +2229,9 @@
 
         // Toggle fullscreen
         function _toggleFullscreen(event) {
+            if (plyr.type === 'audio') {
+              return
+            }
             // Check for native support
             var nativeSupport = fullscreen.supportsFullScreen;
 
@@ -3192,6 +3195,9 @@
 
             // Fullscreen
             _proxyListener(plyr.buttons.fullscreen, 'click', config.listeners.fullscreen, _toggleFullscreen);
+
+            // Toggle fullscreen when user double clicks on video wrapper
+            _proxyListener(plyr.container, 'dblclick', config.listeners.fullscreen, _toggleFullscreen);
 
             // Handle user exiting fullscreen by escaping etc
             if (fullscreen.supportsFullScreen) {


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/446#issuecomment-353689695

### Sumary of proposed changes
Added a double click listener on video container to toggle full screen

### Task list

- [x] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed