### PR TITLE
Fix `enabled` smartphone example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1024,7 +1024,7 @@ Fullscreen in Plyr is supported by all browsers that [currently support it](http
 The `enabled` option can be used to disable certain User Agents. For example, if you don't want to use Plyr for smartphones, you could use:
 
 ```javascript
-enabled: /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)
+enabled: !/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)
 ```
 If a User Agent is disabled but supports `<video>` and `<audio>` natively, it will use the native player.
 


### PR DESCRIPTION
### Link to related issue (if applicable)

*not applicable*

### Sumary of proposed changes

This fixes the `enabled:` example for disabling plyr on smartphones, as it's the opposite of what it needs to be.

### Task list

*not applicable*

- [] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [] Gulp build completed