### PR TITLE
Beta with ads - Added promises, missing events, new ad tag and additional logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ index-*.html
 npm-debug.log
 *.webm
 /package-lock.json
+.idea/
+

--- a/demo/src/js/demo.js
+++ b/demo/src/js/demo.js
@@ -52,8 +52,12 @@ document.addEventListener('DOMContentLoaded', () => {
             google: 'AIzaSyDrNwtN3nLH_8rjCmu5Wq3ZCm4MNAVdc0c',
         },
         ads: {
-            tagUrl:
-                'http://go.aniview.com/api/adserver6/vast/?AV_PUBLISHERID=58c25bb0073ef448b1087ad6&AV_CHANNELID=5a0458dc28a06145e4519d21&AV_URL=127.0.0.1:3000&cb=1&AV_WIDTH=640&AV_HEIGHT=480',
+            tagUrl: 'https://pubads.g.doubleclick.net/gampad/ads' +
+            '?sz=640x480&iu=/124319096/external/ad_rule_samples&' +
+            'ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&' +
+            'output=vmap&unviewed_position_start=1&cust_params=d' +
+            'eployment%3Ddevsite%26sample_ar%3Dpremidpostoptimiz' +
+            'edpod&cmsid=496&vid=short_onecue&correlator=',
         },
     });
 


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/pull/760

### Sumary of proposed changes
Added promises to make sure our advertisement is ready before calling play. This setup will also make it possible - with some adjustments - to request new advertisements when the video src changes. Added other IMA events to hook into. Added debug logs. Added a VAST tag that will show a preroll, midroll on 15sec in video and at the end of a video a postroll; for better testing. Also added a safety timer in case the IMA CDN is down or ad providers do something spooky.

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed