### PR TITLE
Fix harmless but annoying IE error 'IndexSizeError'

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -124,7 +124,8 @@ const captions = {
     setCue(input) {
         // Get the track from the event if needed
         const track = utils.is.event(input) ? input.target : input;
-        const active = track.activeCues[0];
+        const {activeCues} = track;
+        const active = activeCues.length && activeCues[0];
         const currentTrack = captions.getCurrentTrack.call(this);
 
         // Only display current track


### PR DESCRIPTION
Note: This is not a fix for #771. It's just avoiding an error thrown frequently by IE11 trying to access `activeCues[0]` when `activeCues` is empty.

This doesn't happen in other browsers or in IE11 with normal arrays afaik. Really weird.