### PR TITLE
Advertisement couldnt be loaded when creative dimensions do not align after resizing

### DIFF
--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -259,7 +259,7 @@ const defaults = {
         // Ads
         'adsloaded',
         'adscontentpause',
-        'adsconentresume',
+        'adscontentresume',
         'adstarted',
         'adsmidpoint',
         'adscomplete',

--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -206,7 +206,7 @@ class Ads {
 
         // Add advertisement cue's within the time line if available
         this.cuePoints.forEach(cuePoint => {
-            if (cuePoint !== 0 && cuePoint !== -1) {
+            if (cuePoint !== 0 && cuePoint !== -1 && cuePoint < this.player.duration) {
                 const seekElement = this.player.elements.progress;
 
                 if (seekElement) {

--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -68,9 +68,9 @@ class Ads {
         // Setup a promise to resolve when the IMA manager is ready
         this.managerPromise = new Promise((resolve, reject) => {
             // The ad is pre-loaded and ready
-            this.on('ADS_MANAGER_LOADED', () => resolve());
+            this.on('ADS_MANAGER_LOADED', resolve);
             // Ads failed
-            this.on('ERROR', () => reject());
+            this.on('ERROR', reject);
         });
     }
 
@@ -503,7 +503,7 @@ class Ads {
 
             // Re-set our adsManager promises
             this.managerPromise = new Promise(resolve => {
-                this.on('ADS_MANAGER_LOADED', () => resolve());
+                this.on('ADS_MANAGER_LOADED', resolve);
                 this.player.debug.log(this.manager);
             });
 

--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -111,7 +111,6 @@ class Ads {
         // Create the container for our advertisements
         this.elements.container = utils.createElement('div', {
             class: this.player.config.classNames.ads,
-            hidden: '',
         });
         this.player.elements.container.appendChild(this.elements.container);
 
@@ -451,8 +450,8 @@ class Ads {
      * Resume our video.
      */
     resumeContent() {
-        // Hide our ad container
-        utils.toggleHidden(this.elements.container, true);
+        // Hide the advertisement container
+        this.elements.container.style.zIndex = '';
 
         // Ad is stopped
         this.playing = false;
@@ -467,8 +466,8 @@ class Ads {
      * Pause our video
      */
     pauseContent() {
-        // Show our ad container.
-        utils.toggleHidden(this.elements.container, false);
+        // Show the advertisement container
+        this.elements.container.style.zIndex = '3';
 
         // Ad is playing.
         this.playing = true;

--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -36,9 +36,8 @@ class Ads {
         this.playing = false;
         this.initialized = false;
         this.blocked = false;
-        this.enabled = utils.is.url(player.config.ads.tag);
 
-        // Check if a tag URL is provided.
+        // Check if ads are enabled.
         if (!this.enabled) {
             return;
         }
@@ -83,14 +82,12 @@ class Ads {
         // thing doesn't resolve within our set time; we bail
         this.startSafetyTimer(12000, 'ready()');
 
-        // Setup a simple promise to resolve if the IMA loader is ready
-        this.loaderPromise = new Promise(resolve => {
-            this.on('ADS_LOADER_LOADED', () => resolve());
-        });
-
         // Setup a promise to resolve if the IMA manager is ready
-        this.managerPromise = new Promise(resolve => {
+        this.managerPromise = new Promise((resolve, reject) => {
+            // The ad is pre-loaded and ready
             this.on('ADS_MANAGER_LOADED', () => resolve());
+            // Ads failed
+            this.on('ERROR', () => reject());
         });
 
         // Clear the safety timer

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -311,10 +311,10 @@ class Plyr {
     play() {
         // Return the promise (for HTML5)
         if (this.ads.enabled && !this.ads.initialized) {
-            this.ads.managerPromise.then(() => {
+            return this.ads.managerPromise.then(() => {
                 this.ads.play();
             }).catch(() => {
-                return this.media.play();
+                this.media.play();
             });
         } else {
             return this.media.play();

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -309,14 +309,15 @@ class Plyr {
      * Play the media, or play the advertisement (if they are not blocked)
      */
     play() {
-        // TODO: Always return a promise?
         if (this.ads.enabled && !this.ads.initialized && !this.ads.blocked) {
-            this.ads.play();
-            return null;
+            this.ads.managerPromise.then(() => {
+                this.ads.play();
+            }).catch(() => {
+                this.media.play();
+            });
+        } else {
+            this.media.play();
         }
-
-        // Return the promise (for HTML5)
-        return this.media.play();
     }
 
     /**

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -309,14 +309,15 @@ class Plyr {
      * Play the media, or play the advertisement (if they are not blocked)
      */
     play() {
-        if (this.ads.enabled && !this.ads.initialized && !this.ads.blocked) {
+        // Return the promise (for HTML5)
+        if (this.ads.enabled && !this.ads.initialized) {
             this.ads.managerPromise.then(() => {
                 this.ads.play();
             }).catch(() => {
-                this.media.play();
+                return this.media.play();
             });
         } else {
-            this.media.play();
+            return this.media.play();
         }
     }
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -316,9 +316,9 @@ class Plyr {
             }).catch(() => {
                 this.media.play();
             });
-        } else {
-            return this.media.play();
         }
+
+        return this.media.play();
     }
 
     /**

--- a/src/sass/plugins/ads.scss
+++ b/src/sass/plugins/ads.scss
@@ -12,15 +12,11 @@
     z-index: -1; // Hide it.
 
     // Make sure the inner container is big enough for the ad creative.
-    > div {
+    > div,
+    > div iframe {
         position: absolute;
         width: 100%;
         height: 100%;
-        iframe {
-            position: absolute;
-            width: 100%;
-            height: 100%;
-        }
     }
 
     &::after {

--- a/src/sass/plugins/ads.scss
+++ b/src/sass/plugins/ads.scss
@@ -9,7 +9,19 @@
     position: absolute;
     right: 0;
     top: 0;
-    z-index: 3; // Above the controls
+    z-index: -1; // Hide it.
+
+    // Make sure the inner container is big enough for the ad creative.
+    > div {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        iframe {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
+    }
 
     &::after {
         background: rgba($plyr-color-gunmetal, 0.8);


### PR DESCRIPTION
### Link to related issue (if applicable)

### Sumary of proposed changes
Found some issues concerning where ads can't be loaded because the "creative dimensions" do not align with the size of the ad container after resizing the video/ ad container. 

Another thing; It looked weird when the video starts playing, but the ad manager is still getting ready. You would get a split second video and then the ad starts, so i added a promise within the play() method which waits until the ads manager is ready or something failed. Normally this doesn't happen often as everything gets ready quicker then a video, but when there is video header bidding in place or something it could get quite slow enough.

Would be cool if someone could also hook this up to the progress/ buffer/ preloader thing. 

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed