### PR TITLE
[v3] Add optional arguments to Ads.trigger

### DIFF
--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -50,8 +50,9 @@ class Ads {
                     })
                     .catch(() => {
                         // Script failed to load or is blocked
-                        this.trigger('ERROR');
-                        this.player.debug.error('Google IMA SDK failed to load');
+                        const message = 'Google IMA SDK failed to load';
+                        this.trigger('ERROR', new Error(message));
+                        this.player.debug.error(message);
                     });
             } else {
                 this.ready();
@@ -518,13 +519,13 @@ class Ads {
      * Handles callbacks after an ad event was invoked
      * @param {string} event - Event type
      */
-    trigger(event) {
+    trigger(event, ...args) {
         const handlers = this.events[event];
 
         if (utils.is.array(handlers)) {
             handlers.forEach(handler => {
                 if (utils.is.function(handler)) {
-                    handler.call(this);
+                    handler.apply(this, args);
                 }
             });
         }


### PR DESCRIPTION
Ads.trigger now takes optional arguments so you can pass arguments to the listeners.
This is used to fix https://github.com/sampotts/plyr/pull/802#issuecomment-372034259 by getting a showing a more specific error if Ads are blocked.

The value of the debug line is questionable since it's basically repeating the error. But I guess the error could be caught, so I'll left it.