### PR TITLE
Fix player seeking not working for Vimeo

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1930,9 +1930,6 @@
             plyr.media.paused = true;
             plyr.media.currentTime = 0;
 
-            // Update UI
-            _embedReady();
-
             plyr.embed.getCurrentTime().then(function(value) {
                 plyr.media.currentTime = value;
 
@@ -1958,6 +1955,19 @@
                 if (_is.htmlElement(plyr.embed.element) && plyr.supported.full) {
                     plyr.embed.element.setAttribute('tabindex', '-1');
                 }
+
+                // Fix player not seeking
+                // https://github.com/sampotts/plyr/issues/537
+                // https://github.com/sampotts/plyr/issues/208
+                plyr.embed.getDuration().then(function(value) {
+                    plyr.media.duration = value;
+
+                    // Trigger timeupdate
+                    _triggerEvent(plyr.media, 'durationchange');
+
+                    // Update UI
+                    _embedReady();
+                });
             });
 
             plyr.embed.on('play', function() {

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -2170,7 +2170,12 @@
 
                     case 'vimeo':
                         // Round to nearest second for vimeo
-                        plyr.embed.setCurrentTime(targetTime.toFixed(0));
+                        plyr.embed.setCurrentTime(targetTime.toFixed(0)).then(function () {
+                            // Prevent player from playing after seeking, if it was paused
+                            if (paused) {
+                                _pause();
+                            }
+                        });
                         break;
 
                     case 'soundcloud':


### PR DESCRIPTION
### Link to related issue (if applicable)
#208 #537

### Sumary of proposed changes
First off, I am not much experienced with JavaScript development, so this solution might or might not be correct. 

I've just moved the Plyr load function to execute when Vimeo player has loaded (and thus has duration value). Seeking on `ready` event did not work because duration value was `0`, and based on my assumption - it's because Vimeo player didn't fetch the data yet. 

So, this code change fixes the issue with seeking.

Tested on Chromium on Arch Linux.

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed