### PR TITLE
Fix loading data-plyr-config when initiating Plyr without any options

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -57,7 +57,7 @@ class Plyr {
         this.config = utils.extend(
             {},
             defaults,
-            options,
+            options || {},
             (() => {
                 try {
                     return JSON.parse(this.media.getAttribute('data-plyr-config'));


### PR DESCRIPTION
`utils.extend()` works by iterating itself over each argument until the argument is no longer an object, in which case the iteration is ended. So `utils.extend({}, defaults, undefined, moreOptions)` will ignore `moreOptions`.

While this might be where the real issue is (depending on the intention), I didn't want to assume this was unintentional.