### PR TITLE
Remove settings dependency on 'speed'

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -725,9 +725,6 @@ const controls = {
         const toggle = !utils.is.empty(this.options.speed) && this.options.speed.length > 1;
         controls.toggleTab.call(this, type, toggle);
 
-        // Check if we need to toggle the parent
-        controls.checkMenu.call(this);
-
         // If we're hiding, nothing more to do
         if (!toggle) {
             return;

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -530,6 +530,7 @@ const controls = {
     // Update the selected setting
     updateSetting(setting, container, input) {
         const pane = this.elements.settings.panes[setting];
+        const tab = this.elements.settings.tabs[setting];
         let value = null;
         let list = container;
 
@@ -567,8 +568,8 @@ const controls = {
         }
 
         // Update the label
-        if (!utils.is.empty(value)) {
-            const label = this.elements.settings.tabs[setting].querySelector(`.${this.config.classNames.menu.value}`);
+        if (tab && !utils.is.empty(value)) {
+            const label = tab.querySelector(`.${this.config.classNames.menu.value}`);
             label.innerHTML = controls.getLabel.call(this, setting, value);
         }
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -93,6 +93,9 @@ const ui = {
 
         // Set the title
         ui.setTitle.call(this);
+
+        // Check if we should show the settings icon
+        controls.checkMenu.call(this);
     },
 
     // Setup aria attribute for play and iframe title


### PR DESCRIPTION
### Link to related issue
#865

### Sumary of proposed changes
Moved the call to `checkMenu` from `setSpeedMenu` to the main Plyr constructor. 
In my tests the settings icon will show with either captions or speed in it, but not if it's an empty array. I haven't tested further than that.

I'm not fully sure this is safe, and I guess you might have a different solution in mind. So please be critical.