### PR TITLE
Fix string "null" being appended after the video if controls argument is empty.

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1233,7 +1233,7 @@ const controls = {
         // Inject controls HTML
         if (utils.is.element(container)) {
             target.appendChild(container);
-        } else {
+        } else if (container) {
             target.insertAdjacentHTML('beforeend', container);
         }
 


### PR DESCRIPTION
Initiating plyr without any controls (`new Plyr(video, {controls: []})`) causes a `null` string to be appended after the video element.

(Tested with latest Chrome on El Capitan osx, but I don't think this matters).

This fixes that issue. It's possible it also fixes #815 (which is really a support issue, not a bug apart from the `null`).