### PR TITLE
Fix #867: Add custom property fallback

### DIFF
--- a/src/sass/components/sliders.scss
+++ b/src/sass/components/sliders.scss
@@ -19,7 +19,7 @@
 
     &::-webkit-slider-runnable-track {
         @include plyr-range-track();
-        background-image: linear-gradient(to right, currentColor var(--value), transparent var(--value));
+        background-image: linear-gradient(to right, currentColor var(--value, 0%), transparent var(--value, 0%));
     }
 
     &::-webkit-slider-thumb {


### PR DESCRIPTION
Adds custom property fallback 0% for the slider value.

It doesn't change the slider behavior in Safari in my tests, but should prevent the build warning detailed in #867