### PR TITLE
Fixes issue leaving fullscreen in Chrome using button

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -193,7 +193,7 @@ class Fullscreen {
         } else if (!Fullscreen.native) {
             toggleFallback.call(this, false);
         } else if (!this.prefix) {
-            document.cancelFullScreen();
+            (document.cancelFullScreen || document.exitFullscreen).call(document);
         } else if (!utils.is.empty(this.prefix)) {
             const action = this.prefix === 'moz' ? 'Cancel' : 'Exit';
             document[`${this.prefix}${action}${this.name}`]();


### PR DESCRIPTION
Fixes #873 

Should be safe, but there are probably more elegant solutions.

Also note: The button title/ popover still says "Enter fullscreen" in Chrome