### PR TITLE
Allow the quality to be a string

### DIFF
--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -5,6 +5,14 @@
 import support from './support';
 import utils from './utils';
 
+function mapQualityUnit(input) {
+    const resolution = parseInt(input, 10);
+    if (utils.is.number(resolution)) {
+        return resolution;
+    }
+    return input;
+}
+
 const html5 = {
     getSources() {
         if (!this.isHTML5) {
@@ -36,7 +44,7 @@ const html5 = {
         }
 
         // Reduce to unique list
-        return utils.dedupe(sizes.map(source => Number(source.getAttribute('size'))));
+        return utils.dedupe(sizes.map(source => mapQualityUnit(source.getAttribute('size'))));
     },
 
     extend() {
@@ -62,7 +70,7 @@ const html5 = {
                     return null;
                 }
 
-                return Number(matches[0].getAttribute('size'));
+                return mapQualityUnit(matches[0].getAttribute('size'));
             },
             set(input) {
                 // Get sources
@@ -73,7 +81,7 @@ const html5 = {
                 }
 
                 // Get matches for requested size
-                const matches = Array.from(sources).filter(source => Number(source.getAttribute('size')) === input);
+                const matches = Array.from(sources).filter(source => mapQualityUnit(source.getAttribute('size')) === input);
 
                 // No matches for requested size
                 if (utils.is.empty(matches)) {

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -677,18 +677,18 @@ class Plyr {
         let quality = null;
 
         if (!utils.is.empty(input)) {
-            quality = Number(input);
+            quality = input;
         }
 
-        if (!utils.is.number(quality) || quality === 0) {
+        if (utils.is.empty(quality)) {
             quality = this.storage.get('quality');
         }
 
-        if (!utils.is.number(quality)) {
+        if (utils.is.empty(quality)) {
             quality = this.config.quality.selected;
         }
 
-        if (!utils.is.number(quality)) {
+        if (utils.is.empty(quality)) {
             quality = this.config.quality.default;
         }
 


### PR DESCRIPTION
### Sumary of proposed changes
In my case I needed the qualities to be represented as string, because one of them is `audiodescription`.

I removed the `Number()` calls and replaced them with a new function called `mapQualityUnit`. It converts numbers to numbers, and keeps strings to be strings.

### Task list
- [x] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed