### PR TITLE
Increase menu container z-index to be higher than controls

### DIFF
--- a/src/sass/components/menus.scss
+++ b/src/sass/components/menus.scss
@@ -35,7 +35,7 @@
         right: -3px;
         text-align: left;
         white-space: nowrap;
-        z-index: 1;
+        z-index: 3;
 
         > div {
             overflow: hidden;


### PR DESCRIPTION
### Sumary of proposed changes

Right now the controls z-index value is 2, and the settings menu z-index is 1. If there is an audio player beneath another video or audio player, the settings menu will partially hide under the controls of the player above. It also prevents selecting some of the values in the menu. Here is a screenshot:

<img width="496" alt="screen shot 2018-04-11 at 14 57 37" src="https://user-images.githubusercontent.com/3842168/38616046-57553c86-3d9b-11e8-81ef-99ad2d10ae66.png">

This pr would change the menu container to have a z-index value of 3. I don't see any problems with this, but I could be missing something?


### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed