### PR TITLE
Add i18n support for "Normal" value in speed options

### DIFF
--- a/controls.md
+++ b/controls.md
@@ -59,6 +59,7 @@ i18n: {
     captions: 'Captions',
     settings: 'Settings',
     speed: 'Speed',
+    normal: 'Normal',
     quality: 'Quality',
     loop: 'Loop',
     start: 'Start',

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -511,7 +511,7 @@ const controls = {
     getLabel(setting, value) {
         switch (setting) {
             case 'speed':
-                return value === 1 ? 'Normal' : `${value}&times;`;
+                return value === 1 ? i18n.get('normal', this.config) : `${value}&times;`;
 
             case 'quality':
                 if (utils.is.number(value)) {

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -177,6 +177,7 @@ const defaults = {
         captions: 'Captions',
         settings: 'Settings',
         speed: 'Speed',
+        normal: 'Normal',
         quality: 'Quality',
         loop: 'Loop',
         start: 'Start',


### PR DESCRIPTION
### Sumary of proposed changes

In speed options, if value is 1 then "Normal" is shown instead. This pr adds a new "normal" key to i18n options so that it's possible to translate that string.

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed