### PR TITLE
Safer check for active caption

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -845,7 +845,7 @@ class Plyr {
         }
 
         // If the method is called without parameter, toggle based on current value
-        const show = utils.is.boolean(input) ? input : this.elements.container.className.indexOf(this.config.classNames.captions.active) === -1;
+        const show = utils.is.boolean(input) ? input : !this.elements.container.classList.contains(this.config.classNames.captions.active);
 
         // Nothing to change...
         if (this.captions.active === show) {


### PR DESCRIPTION
Some browsers don't seem to support `className` as a string that can be used with `indexOf` so they throw when using captions like this:

`Uncaught TypeError: a[b].target.className.indexOf is not a function`

### Summary of proposed changes

I've just swapped that by `classList.contains` which should be safer and also (IMHO) clearer.

### Task list

- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed