### PR TITLE
Fix IE10 split error

### DIFF
--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -115,7 +115,7 @@ const defaults = {
     // Captions settings
     captions: {
         active: false,
-        language: window.navigator.language && window.navigator.language.split('-')[0],
+        language: window.navigator.language ? window.navigator.language.split('-')[0] : 'en',
     },
 
     // Fullscreen settings

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -115,7 +115,7 @@ const defaults = {
     // Captions settings
     captions: {
         active: false,
-        language: window.navigator.language.split('-')[0],
+        language: window.navigator.language && window.navigator.language.split('-')[0],
     },
 
     // Fullscreen settings


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/893

### Sumary of proposed changes
On IE10, Plyr throws the error `Unable to get property 'split' of undefined or null reference`. This fixes the case when `window.navigator.language` is null and can't use the `split()` function.

### Task list

- [x] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ ] Gulp build completed