### PR TITLE
Show captions even if toggle button is omitted from controls

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -250,11 +250,6 @@ const captions = {
 
     // Display captions container and button (for initialization)
     show() {
-        // If there's no caption toggle, bail
-        if (!utils.is.element(this.elements.buttons.captions)) {
-            return;
-        }
-
         // Try to load the value from storage
         let active = this.storage.get('captions');
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -845,8 +845,8 @@ class Plyr {
      * @param {boolean} input - Whether to enable captions
      */
     toggleCaptions(input) {
-        // If there's no full support, or there's no caption toggle
-        if (!this.supported.ui || !utils.is.element(this.elements.buttons.captions)) {
+        // If there's no full support
+        if (!this.supported.ui) {
             return;
         }
 


### PR DESCRIPTION
Fixes #901

Just removed the conditions to check the button. Switching via settings or `player.toggleCaptions()` now works without the toggle button, as well as getting the right settings from either localStorage or the settings passed to Plyr.

This makes a lot more sense to me and I don't think the old check should be replaced with something else like checking if either the toggler or caption setting (with languages) elements exists. Better to respect user settings.