### PR TITLE
Fullscreen aria-pressed event listened fix for Chrome

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -90,7 +90,7 @@ class Fullscreen {
     static get prefix() {
         // No prefix
         if (utils.is.function(document.exitFullscreen)) {
-            return false;
+            return '';
         }
 
         // Check for fullscreen support by vendor prefix


### PR DESCRIPTION
Fixes #881 

The reason this happens is because the `prefix` getter is set to `false` when document.exitFullscreen is a function (true for Chrome):

```js
if (utils.is.function(document.exitFullscreen)) {
    return false;
}
```

And the event listener concatenates that to `falsefullscreenchange`

```js
utils.on(document, this.prefix === 'ms' ? 'MSFullscreenChange' : `${this.prefix}fullscreenchange`, () => {
    // TODO: Filter for target??
    onChange.call(this);
});
```

I choose to change it in the first place, for type consistency, but falling back to `''` for falsy prefixes in the event name concatenation would have worked as well.