### PR TITLE
Added 480p to SD labels

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -483,6 +483,7 @@ const controls = {
                     break;
 
                 case 576:
+                case 480:
                     label = 'SD';
                     break;
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Sumary of proposed changes
Updated the control.js file to add a `SD` label to sources with a 480 value on the size attribute
### Task list

- [X ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [ X] Gulp build completed