### PR TITLE
Poster fixes

### DIFF
--- a/src/sass/components/poster.scss
+++ b/src/sass/components/poster.scss
@@ -6,7 +6,7 @@
     background-color: #000;
     background-position: 50% 50%;
     background-repeat: no-repeat;
-    background-size: 100% 100%;
+    background-size: contain;
     height: 100%;
     left: 0;
     opacity: 0;

--- a/src/sass/components/poster.scss
+++ b/src/sass/components/poster.scss
@@ -15,6 +15,7 @@
     transition: opacity 0.3s ease;
     width: 100%;
     z-index: 1;
+    pointer-events: none;
 }
 
 .plyr--stopped .plyr__poster {


### PR DESCRIPTION
A couple of css fixes to the poster

1. Letterbox the poster rather than stretching it. This is how html5 video posters normally behave.
2. Add `pointer-events: none;` as suggested by @mhluska. I haven't reproduced #946 but think this should be safe either way.