### PR TITLE
Fix the seek tooltip time difference from seek time

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -443,7 +443,7 @@ const controls = {
 
         // Calculate percentage
         let percent = 0;
-        const clientRect = this.elements.inputs.seek.getBoundingClientRect();
+        const clientRect = this.elements.progress.getBoundingClientRect();
         const visible = `${this.config.classNames.tooltip}--visible`;
 
         const toggle = toggle => {

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -529,12 +529,30 @@ class Listeners {
             }
         });
 
+        // Set range input alternative "value", which matches the tooltip time (#954)
+        on(
+            this.player.elements.inputs.seek,
+            'mousedown mousemove',
+            event => {
+                const clientRect = this.player.elements.progress.getBoundingClientRect();
+                const percent = 100 / clientRect.width * (event.pageX - clientRect.left);
+                event.currentTarget.setAttribute('seekNext', percent);
+            }
+        );
+
         // Seek
         on(
             this.player.elements.inputs.seek,
             inputEvent,
             event => {
-                this.player.currentTime = event.target.value / event.target.max * this.player.duration;
+                const seek = event.currentTarget;
+                // If it exists, use seekNext instead of "value" for consistency with tooltip time (#954)
+                let seekTo = seek.getAttribute('seekNext');
+                if (utils.is.empty(seekTo)) {
+                    seekTo = seek.value;
+                }
+                seek.removeAttribute('seekNext');
+                this.player.currentTime = seekTo / seek.max * this.player.duration;
             },
             'seek',
         );

--- a/src/sass/components/progress.scss
+++ b/src/sass/components/progress.scss
@@ -6,10 +6,15 @@
     display: flex;
     flex: 1;
     position: relative;
+    margin-right: $plyr-range-thumb-height;
+    left: $plyr-range-thumb-height / 2;
 
     input[type='range'] {
         position: relative;
         z-index: 2;
+        // Offset the range thumb in order to be able to calculate the relative progress (#954)
+        width: calc(100% + #{$plyr-range-thumb-height}) !important;
+        margin: 0 -#{$plyr-range-thumb-height / 2} !important;
     }
 
     // Seek tooltip to show time


### PR DESCRIPTION
Hacky proposed fix for #687 #954 (and perhaps #808, but I don't understand it) using the sass var `$plyr-range-thumb-height` and negative margins to make the container the same size as the area the center point of the range thumb can move.

Tested in Chrome, Firefox and Safari.
Firefox worked perfectly. I still got a tiny difference for Chrome and Safari. Testing with the plyr demo videos maybe 1/10 time you click you get a second difference between the tooltip and seek time. Testing with a 2 hour movie on youtube it's as much as 10 seconds (instead of up to 2 minutes).

The second commit fixes this by adding an alternative `value` calculated with the exact same way as the tooltip times, before the seek slider's change event.

Users can still change the thumb size by changing the sass variable or custom css to override every place it's used. Not optimal, but at least possible :/