### PR TITLE
Youtube and vimeo fixes

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -481,6 +481,7 @@ const controls = {
                 // Video playing
                 case 'timeupdate':
                 case 'seeking':
+                case 'seeked':
                     value = utils.getPercentage(this.currentTime, this.duration);
 
                     // Set seek range value only if it's a 'natural' time event

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -602,9 +602,10 @@ const controls = {
         controls.updateProgress.call(this, event);
     },
 
-    // Show the duration on metadataloaded
+    // Show the duration on metadataloaded or durationchange events
     durationUpdate() {
-        if (!this.supported.ui) {
+        // Bail if no ui or durationchange event triggered after playing/seek when invertTime is false
+        if (!this.supported.ui || (!this.config.invertTime && this.currentTime)) {
             return;
         }
 

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -273,7 +273,7 @@ class Listeners {
     // Listen for media events
     media() {
         // Time change on media
-        utils.on(this.player.media, 'timeupdate seeking', event => controls.timeUpdate.call(this.player, event));
+        utils.on(this.player.media, 'timeupdate seeking seeked', event => controls.timeUpdate.call(this.player, event));
 
         // Display duration
         utils.on(this.player.media, 'durationchange loadeddata loadedmetadata', event => controls.durationUpdate.call(this.player, event));
@@ -295,7 +295,7 @@ class Listeners {
         });
 
         // Check for buffer progress
-        utils.on(this.player.media, 'progress playing', event => controls.updateProgress.call(this.player, event));
+        utils.on(this.player.media, 'progress playing seeking seeked', event => controls.updateProgress.call(this.player, event));
 
         // Handle volume changes
         utils.on(this.player.media, 'volumechange', event => controls.updateVolume.call(this.player, event));

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -149,25 +149,26 @@ const vimeo = {
                 return currentTime;
             },
             set(time) {
-                // Get current paused state
-                // Vimeo will automatically play on seek
-                const { paused } = player.media;
+                // Vimeo will automatically play on seek if the video hasn't been played before
 
-                // Set seeking flag
-                player.media.seeking = true;
+                // Get current paused state and volume etc
+                const { embed, media, paused, volume } = player;
 
-                // Trigger seeking
-                utils.dispatchEvent.call(player, player.media, 'seeking');
+                // Set seeking state and trigger event
+                media.seeking = true;
+                utils.dispatchEvent.call(player, media, 'seeking');
 
-                // Seek after events
-                player.embed.setCurrentTime(time).catch(() => {
-                    // Do nothing
-                });
-
-                // Restore pause state
-                if (paused) {
-                    player.pause();
-                }
+                // If paused, mute until seek is complete
+                Promise.resolve(paused && embed.setVolume(0))
+                    // Seek
+                    .then(() => embed.setCurrentTime(time))
+                    // Restore paused
+                    .then(() => paused && embed.pause())
+                    // Restore volume
+                    .then(() => paused && embed.setVolume(volume))
+                    .catch(() => {
+                        // Do nothing
+                    });
             },
         });
 
@@ -357,7 +358,6 @@ const vimeo = {
         player.embed.on('seeked', () => {
             player.media.seeking = false;
             utils.dispatchEvent.call(player, player.media, 'seeked');
-            utils.dispatchEvent.call(player, player.media, 'play');
         });
 
         player.embed.on('ended', () => {

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -7,6 +7,14 @@ import controls from './../controls';
 import ui from './../ui';
 import utils from './../utils';
 
+// Set playback state and trigger change (only on actual change)
+function assurePlaybackState(play) {
+    if (this.media.paused === play) {
+        this.media.paused = !play;
+        utils.dispatchEvent.call(this, this.media, play ? 'play' : 'pause');
+    }
+}
+
 const vimeo = {
     setup() {
         // Add embed class for responsive
@@ -120,15 +128,13 @@ const vimeo = {
 
         // Create a faux HTML5 API using the Vimeo API
         player.media.play = () => {
-            player.embed.play().then(() => {
-                player.media.paused = false;
-            });
+            assurePlaybackState.call(player, true);
+            return player.embed.play();
         };
 
         player.media.pause = () => {
-            player.embed.pause().then(() => {
-                player.media.paused = true;
-            });
+            assurePlaybackState.call(player, false);
+            return player.embed.pause();
         };
 
         player.media.stop = () => {
@@ -315,17 +321,12 @@ const vimeo = {
         });
 
         player.embed.on('play', () => {
-            // Only fire play if paused before
-            if (player.media.paused) {
-                utils.dispatchEvent.call(player, player.media, 'play');
-            }
-            player.media.paused = false;
+            assurePlaybackState.call(player, true);
             utils.dispatchEvent.call(player, player.media, 'playing');
         });
 
         player.embed.on('pause', () => {
-            player.media.paused = true;
-            utils.dispatchEvent.call(player, player.media, 'pause');
+            assurePlaybackState.call(player, false);
         });
 
         player.embed.on('timeupdate', data => {

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -424,6 +424,17 @@ const youtube = {
                     // Reset timer
                     clearInterval(player.timers.playing);
 
+                    const seeked = player.media.seeking && [
+                        1,
+                        2,
+                    ].includes(event.data);
+
+                    if (seeked) {
+                        // Unset seeking and fire seeked event
+                        player.media.seeking = false;
+                        utils.dispatchEvent.call(player, player.media, 'seeked');
+                    }
+
                     // Handle events
                     // -1   Unstarted
                     // 0    Ended
@@ -457,12 +468,6 @@ const youtube = {
                             break;
 
                         case 1:
-                            // If we were seeking, fire seeked event
-                            if (player.media.seeking) {
-                                player.media.seeking = false;
-                                utils.dispatchEvent.call(player, player.media, 'seeked');
-                            }
-
                             // Restore paused state (YouTube starts playing on seek if the video hasn't been played yet)
                             if (player.media.paused) {
                                 player.media.pause();


### PR DESCRIPTION
I merged these into one PR since I couldn't submit them separately without conflicts, but they are separate commits.

#### #876 Fix Youtube and vimeo autoplay on initial seek

Prevents the default behavior to start playing when seeking for the first time, by muting, pausing and then unmuting again.

Uses the youtube and vimeo apis to change state, but never sets the state to the instance, in order to restore it from the instance and apply.

Seeking while paused for youtube is still pretty broken, but this is a separate issue.

####  #921: Trigger seeked event in youtube plugin if either playing or paused

Before it was only triggered in the "playing" part of the switch statement.

#### #966: Fix youtube seek
Added `seeked` event listeners since currentTime isn't right for the `seeking` event (should fix that separately). Fixees seek for youtube (broken before, but you couldn't tell unless using it while paused)

#### Fix playback state (paused) and events (play/pause)
The `play` and `pause` event means that the `paused` state has changed (w3c words it like that, mdn didn't, but does now since I updated the event page). You can test at: http://jsbin.com/jutiveyefa/edit?console,output
Also made sure the events were triggered both in the `play` and `pause` methods (as they should be) or when detecting that the state changes via the API methods.

#### Prevent durationchange events from showing time when invertTime is false
If invertTime is false the currentTime should be shown when seeking or playing, but since youtube (and perhaps vimeo) can get the duration via the `durationchange` after playing/ initial seek, this causes the remaining time to show instead. 

I'm not sure this is the proper place to fix it.