### PR TITLE
Enable overriding defaults

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -55,6 +55,7 @@ class Plyr {
         this.config = utils.extend(
             {},
             defaults,
+            Plyr.defaults,
             options || {},
             (() => {
                 try {
@@ -1268,5 +1269,7 @@ class Plyr {
         return targets.map(t => new Plyr(t, options));
     }
 }
+
+Plyr.defaults = utils.cloneDeep(defaults);
 
 export default Plyr;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -703,6 +703,11 @@ const utils = {
         return array.filter((item, index) => array.indexOf(item) === index);
     },
 
+    // Clone nested objects
+    cloneDeep(object) {
+        return JSON.parse(JSON.stringify(object));
+    },
+
     // Get the closest value in an array
     closest(array, value) {
         if (!utils.is.array(array) || !array.length) {


### PR DESCRIPTION
Enables changing the defaults to whatever you use the most. For example:

`Object.assign(Plyr.defaults, {invertTime: false, ratio: '16:9', clickToPlay: false, controls: ['play', 'progress', 'current-time', 'mute', 'volume']});`

Rather than having to pass those options each time you initiate a Plyr instance.

I'm quite used to this from other libraries and it would simplify my own Plyr usage as well since the webapp I'm working for uses Plyr in five different places.

The only actual code needed to support this is `Plyr.defaults = defaults`, but that would introduce a risk of users accidentally removing defaults. Ex `Object.assign(Plyr.defaults, {tooltips: {controls: true}})` would remove `defaults.controls.seek`.

I didn't document the changes. Not sure which section to add it to (or if you even like the idea).