### PR TITLE
Restore utils.is.cue()

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -44,7 +44,7 @@ const utils = {
             return this.instanceof(input, Event);
         },
         cue(input) {
-            return this.instanceof(input, TextTrackCue) || this.instanceof(input, VTTCue);
+            return this.instanceof(input, window.TextTrackCue) || this.instanceof(input, window.VTTCue);
         },
         track(input) {
             return this.instanceof(input, TextTrack) || (!this.nullOrUndefined(input) && this.string(input.kind));


### PR DESCRIPTION
Needed since `VTTCue` doesn't exist in IE11. I'm not sure `TextTrackCue` is safe so I added it for both.

This was never really the problem in #951 since that just concerned `window.Plyr`, not referring to the window object in general, so it's safe to use as long as this runs in a browser.

The other references like `WeakMap` should be fine. As long as we rely on them it's better if they throw an error than fail silently imo.

This shouldn't change anything I think, besides not throwing the error.