### PR TITLE
Fix InvalidStateError and IE11 issues

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -432,21 +432,16 @@ class Plyr {
      * @param {number} input - where to seek to in seconds. Defaults to 0 (the start)
      */
     set currentTime(input) {
-        let targetTime = 0;
-
-        if (utils.is.number(input)) {
-            targetTime = input;
+        // Bail if media duration isn't available yet
+        if (!this.duration) {
+            return;
         }
 
-        // Normalise targetTime
-        if (targetTime < 0) {
-            targetTime = 0;
-        } else if (targetTime > this.duration) {
-            targetTime = this.duration;
-        }
+        // Validate input
+        const inputIsValid = utils.is.number(input) && input > 0;
 
         // Set
-        this.media.currentTime = targetTime;
+        this.media.currentTime = inputIsValid ? Math.min(input, this.duration) : 0;
 
         // Logging
         this.debug.log(`Seeking to ${this.currentTime} seconds`);

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -494,11 +494,11 @@ class Plyr {
         // Faux duration set via config
         const fauxDuration = parseFloat(this.config.duration);
 
-        // True duration
-        const realDuration = this.media ? Number(this.media.duration) : 0;
+        // Media duration can be NaN before the media has loaded
+        const duration = (this.media || {}).duration || 0;
 
-        // If custom duration is funky, use regular duration
-        return !Number.isNaN(fauxDuration) ? fauxDuration : realDuration;
+        // If config duration is funky, use regular duration
+        return fauxDuration || duration;
     }
 
     /**


### PR DESCRIPTION
The IE issues happen because the media metadata doesn't load in time before Plyr (for unknown reasons) is trying to set `currentTime`. This in turn triggers an `InvalidStateError` and causes the constructor to fail (it returns the html element, not the instance).

Most of the changes in the PR was just me rephrasing code I thought was redundant while debugging. Since `NaN` is falsy for example `!Number.isNaN(x) ? x : y` is just a more complex way to write `x || y`.

Only the initial condition in the `currentTime` setter should be needed to actually fix the issue.

Also before media elements have loaded, the duration is NaN. `document.createElement('video').duration` for example is `NaN`, not 0. So line 493 should really be `const duration = (this.media || {}).duration || NaN;` if we want to respect the HTML5 media standards.

Let me know which way you want it (or just merge and change it yourself).