### PR TITLE
Respect storage being disabled for storage getter

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -31,7 +31,7 @@ class Storage {
     }
 
     get(key) {
-        if (!Storage.supported) {
+        if (!Storage.supported || !this.enabled) {
             return null;
         }
 


### PR DESCRIPTION
When storage is disabled and you have a localStorage entry from previously, it shouldn't ignore that entry.