### PR TITLE
Remove cors attributes for local links in the demo html

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -175,7 +175,7 @@
         crossorigin="anonymous"></script>
 
     <!-- Plyr core script -->
-    <script src="../dist/plyr.js" crossorigin="anonymous"></script>
+    <script src="../dist/plyr.js"></script>
 
     <!-- Sharing libary (https://shr.one) -->
     <script src="https://cdn.shr.one/1.0.1/shr.js" crossorigin="anonymous"></script>
@@ -184,7 +184,6 @@
     <script src="https://cdn.rangetouch.com/1.0.1/rangetouch.js" async crossorigin="anonymous"></script>
 
     <!-- Docs script -->
-    <script src="dist/demo.js" crossorigin="anonymous"></script>
+    <script src="dist/demo.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
Cors-attributes aren't needed for same-origin content, and creates problems if someone wants to run the demo by opening the file directly in the browser (not sure if that was an intended use case).

Svg still doesn't work for running directly in the browser though.