### PR TITLE
Call duration update method manually if user config has duration

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -109,6 +109,12 @@ const ui = {
         if (this.poster && this.elements.poster && !this.elements.poster.style.backgroundImage) {
             ui.setPoster.call(this, this.poster);
         }
+
+        // Manually set the duration if user has overridden it.
+        // The event listeners for it doesn't get called if preload is disabled (#701)
+        if (this.config.duration) {
+            controls.durationUpdate.call(this);
+        }
     },
 
     // Setup aria attribute for play and iframe title


### PR DESCRIPTION
Fixes #701

The method for setting duration is run via event listeners that listen for when the metadata is ready.

It doesn't get called if the media element has disabled preload (`preload="none"` or with `new Hls({autoStartLoad: false})`), so custom durations are never shown.