### PR TITLE
Proposed changes to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ### Link to related issue (if applicable)
 
-### Sumary of proposed changes
+### Summary of proposed changes
 
-### Task list
-
-- [ ] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
-- [ ] Gulp build completed
+### Checklist
+- [ ] Use `develop` as the base branch
+- [ ] Exclude the gulp build from the PR
+- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)


### PR DESCRIPTION
Update instructions to use the `develop` as the base branch, fix typo and suggest to exclude the gulp build (I think we should avoid it in develop). #990 (created after this PR) should take care of verifying that the build works.