### PR TITLE
Wait for the metadata to be loaded before setting the currentTime

### DIFF
--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -99,6 +99,13 @@ const html5 = {
                 // Set new source
                 player.media.src = supported[0].getAttribute('src');
 
+                // Restore time
+                const onLoadedMetaData = () => {
+                    player.currentTime = currentTime;
+                    player.off('loadedmetadata', onLoadedMetaData);
+                };
+                player.on('loadedmetadata', onLoadedMetaData);
+
                 // Load new source
                 player.media.load();
 
@@ -106,9 +113,6 @@ const html5 = {
                 if (playing) {
                     player.play();
                 }
-
-                // Restore time
-                player.currentTime = currentTime;
 
                 // Trigger change event
                 utils.dispatchEvent.call(player, player.media, 'qualitychange', false, {


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/991

### Sumary of proposed changes
It seems that the currentTime cannot be set before the metadata has been loaded.

### Task list
- [x] Tested on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Gulp build completed

Closes #991