### PR TITLE
Contributing document and codepen demo updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ Describe the issue as detailed as possible, answering these questions:
   * [Hls.js integration](https://codepen.io/pen?template=oyLKQb)
   * [Shaka Player integration](https://codepen.io/pen?template=ZRpzZO)
 
+It's important that you keep the issue description and replication demo **minimal**. If your implementation is using a framework, library or custom methods, which aren't needed to reproduce the issue, this makes it harder to debug and understand the issue. While it may be relevant to bring this up (ex: "I need Plyr to trigger the event sooner or it breaks Framework X") it also means that the person who is trying to fix the issue either has to know or learn your frameworks, libraries and custom methods, or that no one will try to fix your issue because it's too much work.
+
+In order to keep things on topic and to avoid bothering people with github notifications, please don't combine multiple problems or bugs into one issue, don't comment on issues unless your comment is related to that issue, and don't post "+1" or "I agree" type of comments. Use the emojis instead.
+
+Last but not least: Keep a civil tone in issues and comments. Non-constructive comments may be removed.
+
 ## Requesting features and improvements
 
 If you are missing something in Plyr, you can create a GitHub issue for this as well. Since we prioritize fixing bugs first, and may have a lot of other suggestions and architectural changes to work on as well, these may not be at the top of our list. If it's important or urgent to you, you may want to first ensure it's something we want to have in Plyr, and then contribute it as a pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+We welcome bug reports, feature requests and pull requests. If you want to help us out, please follow these guidelines, in order to avoid redundant work.
+
+## Reporting issues
+
+Our GitHub issue tracker is for bug reports and feature requests. Don't create support issues here. Use [Stack Overflow](https://stackoverflow.com/) or [our Slack](https://bit.ly/plyr-chat) for that.
+
+Please verify that your issue hasn't already been answered by our FAQ (https://github.com/sampotts/plyr/wiki/FAQ), or that there isn't already an open issue for it.
+
+When applicable, check that your problem doesn't happen without Plyr (see [FAQ#1](https://github.com/sampotts/plyr/wiki/FAQ#1-does-plyr-work-with--)).
+
+Verify that you are following the documentation, are using the latest version of Plyr, and aren't getting any errors in your own code, causing the issues.
+
+Describe the issue as detailed as possible, answering these questions:
+
+* Does it happen only with specific options and/or specific browsers?
+* Does is happen only with HTML5 video, audio, youtube, vimeo or a specific library?
+* Does the issue happen on [our demo](https://plyr.io/)? If not, please recreate it with a **minimal** example online. You can use our Codepen templates to get started:
+  * [HTML5 video](https://codepen.io/pen?template=bKeqpr)
+  * [HTML5 audio](https://codepen.io/pen?template=rKLywR)
+  * [YouTube](https://codepen.io/pen?template=GGqbbJ)
+  * [Vimeo](https://codepen.io/pen?template=bKeXNq)
+  * [Dash.js integration](https://codepen.io/pen?template=zaBgBy)
+  * [Hls.js integration](https://codepen.io/pen?template=oyLKQb)
+  * [Shaka Player integration](https://codepen.io/pen?template=ZRpzZO)
+
+## Requesting features and improvements
+
+If you are missing something in Plyr, you can create a GitHub issue for this as well. Since we prioritize fixing bugs first, and may have a lot of other suggestions and architectural changes to work on as well, these may not be at the top of our list. If it's important or urgent to you, you may want to first ensure it's something we want to have in Plyr, and then contribute it as a pull request.
+
+## Contributing features and documentation
+
+* Fork Plyr, and create a new branch in your fork, based on the **develop** branch
+
+* To test locally, you can use the demo. First make sure you have installed the dependencies with `npm install` or `yarn`. Run `gulp` to build while you are working, and run a local server from the repository root directory. If you have Python installed, this command should work: `python -m SimpleHTTPServer 8080`. Then go to `http://localhost:8080/demo/`
+
+* Develop and test your modifications.
+
+* Preferably commit your changes as independent logical chunks, with meaningful messages. Make sure you do not commit unnecessary files or changes, such as logging or breakpoints you added for testing, and the build output.
+
+* If your modifications changes the documented behavior or add new features, document these changes in readme.md.
+
+* When finished, push the changes to your GitHub repository and send a pull request to **develop**. Describe what your PR does.
+
+* If the Travis build fails, or if you get a code review with change requests, you can fix these by pushing new or rebased commits to the branch.

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,10 @@ Some awesome folks have made plugins for CMSs and Components for JavaScript fram
 
 Here's a quick run through on getting up and running. There's also a [demo on Codepen](http://codepen.io/sampotts/pen/jARJYp). You can grab all of the source with [NPM](https://www.npmjs.com/package/plyr) using `npm install plyr`.
 
+### Try Plyr online
+
+You can try Plyr in Codepen using our minimal templates: [HTML5 video](https://codepen.io/pen?template=bKeqpr), [HTML5 audio](https://codepen.io/pen?template=rKLywR), [YouTube](https://codepen.io/pen?template=GGqbbJ), [Vimeo](https://codepen.io/pen?template=bKeXNq). For Streaming we also have example integrations with: [Dash.js](https://codepen.io/pen?template=zaBgBy), [Hls.js](https://codepen.io/pen?template=oyLKQb) and [Shaka Player](https://codepen.io/pen?template=ZRpzZO)
+
 ### HTML
 
 Plyr extends upon the standard [HTML5 media element](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement) markup so that's all you need for those types.
@@ -606,17 +610,6 @@ document then the shortcuts will work when any element has focus, apart from an 
 | `F`        | Toggle fullscreen                      |
 | `C`        | Toggle captions                        |
 | `L`        | Toggle loop                            |
-
-## Streaming
-
-Because Plyr is an extension of the standard HTML5 video and audio elements, third party streaming plugins can be used with Plyr. Massive thanks to Matias
-Russitto ([@russitto](https://github.com/russitto)) for working on this. Here's a few examples:
-
-*   Using [hls.js](https://github.com/dailymotion/hls.js) - [Demo](http://codepen.io/sampotts/pen/JKEMqB)
-*   Using [Shaka](https://github.com/google/shaka-player) - [Demo](http://codepen.io/sampotts/pen/zBNpVR)
-*   Using [dash.js](https://github.com/Dash-Industry-Forum/dash.js) - [Demo](http://codepen.io/sampotts/pen/BzpJXN)
-
-_Note_: These need updating to use the new v3 syntax but would still work.
 
 ## Fullscreen
 


### PR DESCRIPTION
I thought the docs could use new updated demos for all formats, to help people get started with minimal implementations when they are testing out Plyr, want to report issues or ask for help.

The links are templates, rather than "pens", meaning they get forked directly by visiting the links. They use unpkg for cdn, since that allows specifying only the major version (v3) of Plyr. So they will use the latest version without needing to be updated (until v4).

Since they're on my codepen, you may want to move them over to yours so you are in control of them. I will be updating the Dash.js and Hls.js ones at a not too distant future though.

I left the previous codepen with custom buttons, since these are meant to get started quickly and that one also demonstrates the JS API usage.

I removed the Streaming section completely since it was redundant with both, but maybe it should be kept and reference back to the templates?

CONTRIBUTING.md is mostly inspired from other libraries, but adapted for Plyr. Since many of our users have shown a remarkable skill for neglecting the issue template, it's another way to reach them. First time they create an issue they should see this:

![screen shot 2018-06-07 at 04 25 24](https://user-images.githubusercontent.com/515120/41074985-e23884de-6a0a-11e8-8876-02031dc398d2.png)

I improvised a lot and you may not agree, or I may have missed something. Feel free to change it.

The part about testing the demo locally is too complicated I think. we should add an npm script for local development that ensures that dependencies are installed, and run gulp (with watch) and a server.

There's some duplication between CONTRIBUTING.md and the FAQ, but I was thinking I would change the last FAQ question to basically link to CONTRIBUTING.md once/if this gets merged.

There's also some duplication is the issue template and PR templates, but I think this is good. CONTRIBUTING.md should be read once, and the templates every time.

I intentionally made master the base branch for this PR, since that way I could make references to CONTRIBUTING.md if this gets merged, before the next release.