### PR TITLE
Vimeo: Update playback state and assure events are triggered on load

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -312,6 +312,14 @@ const vimeo = {
         });
 
         player.embed.on('loaded', () => {
+            // Assure state and events are updated on autoplay
+            player.embed.getPaused().then(paused => {
+                assurePlaybackState.call(player, !paused);
+                if (!paused) {
+                    utils.dispatchEvent.call(player, player.media, 'playing');
+                }
+            });
+
             if (utils.is.element(player.embed.element) && player.supported.ui) {
                 const frame = player.embed.element;
 


### PR DESCRIPTION
Fixes #1016 

Tested in Desktop browsers Chrome (autoplays), Firefox (autoplays) and Safari (doesn't autoplay), and with autoplay enabled or disabled. It works as expected:
  * Events are triggered
  * The play button will show if it's not playing, otherwise the pause button will show

The exception is Safari. When autoplay fails Vimeo will still return `false`. `getPaused()` will still return `false`, as if it's playing. It will trigger `play`, `playing` and `pause`, so in the end the state will still be right.