### PR TITLE
Fix for YouTube and Vimeo pausing after seek

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -9,6 +9,9 @@ import utils from './../utils';
 
 // Set playback state and trigger change (only on actual change)
 function assurePlaybackState(play) {
+    if (play && !this.embed.hasPlayed) {
+        this.embed.hasPlayed = true;
+    }
     if (this.media.paused === play) {
         this.media.paused = !play;
         utils.dispatchEvent.call(this, this.media, play ? 'play' : 'pause');
@@ -153,19 +156,20 @@ const vimeo = {
 
                 // Get current paused state and volume etc
                 const { embed, media, paused, volume } = player;
+                const restorePause = paused && !embed.hasPlayed;
 
                 // Set seeking state and trigger event
                 media.seeking = true;
                 utils.dispatchEvent.call(player, media, 'seeking');
 
                 // If paused, mute until seek is complete
-                Promise.resolve(paused && embed.setVolume(0))
+                Promise.resolve(restorePause && embed.setVolume(0))
                     // Seek
                     .then(() => embed.setCurrentTime(time))
                     // Restore paused
-                    .then(() => paused && embed.pause())
+                    .then(() => restorePause && embed.pause())
                     // Restore volume
-                    .then(() => paused && embed.setVolume(volume))
+                    .then(() => restorePause && embed.setVolume(volume))
                     .catch(() => {
                         // Do nothing
                     });

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -66,6 +66,9 @@ function mapQualityUnits(levels) {
 
 // Set playback state and trigger change (only on actual change)
 function assurePlaybackState(play) {
+    if (play && !this.embed.hasPlayed) {
+        this.embed.hasPlayed = true;
+    }
     if (this.media.paused === play) {
         this.media.paused = !play;
         utils.dispatchEvent.call(this, this.media, play ? 'play' : 'pause');
@@ -469,7 +472,7 @@ const youtube = {
 
                         case 1:
                             // Restore paused state (YouTube starts playing on seek if the video hasn't been played yet)
-                            if (player.media.paused) {
+                            if (player.media.paused && !player.embed.hasPlayed) {
                                 player.media.pause();
                             } else {
                                 assurePlaybackState.call(player, true);


### PR DESCRIPTION
Limited the "YouTube and Vimeo autoplays on seek"-fix to only pause if the video has never been played (which is also the only time it's needed), due to a clash with d733454.

Also prevents temporary muting for Vimeo, but not YouTube. Preventing this shouldn't be needed I think, but changing this for Vimeo didn't adding any redundant code, while the same doesn't apply to YouTube.