### PR TITLE
Event "detail" is lost in the synthetic event bubble/proxy

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -414,7 +414,7 @@ class Listeners {
             'keyup',
             'keydown',
         ]).join(' '), event => {
-            let detail = {};
+            let {detail = {}} = event;
 
             // Get error details from media
             if (event.type === 'error') {


### PR DESCRIPTION
The problem can be tested on the demo:

```js
player.on('qualityrequested', event => console.log('Requested quality:', event.detail.quality));
```

Then when you change quality it should say for example: "Requested quality: 720". But the actual quality is missing.