### PR TITLE
fix: html5.cancelRequest not remove source tag correctly

### DIFF
--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -91,7 +91,7 @@ const html5 = {
         }
 
         // Remove child sources
-        utils.removeElement(html5.getSources());
+        utils.removeElement(html5.getSources.call(this));
 
         // Set blank video src attribute
         // This is to prevent a MEDIA_ERR_SRC_NOT_SUPPORTED error


### PR DESCRIPTION
### Summary of proposed changes

when plyr source changed, `html5.cancelRequest` will be calling to remove all sources in video.
But `html5.getSources` returning empty array because of it not called with correctly context.
To fixed this problem, using `call` to bind correct `this` context to `html5.getSources`

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
