### PR TITLE
Fix condition in events.toggleListener to allow non-elements

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -29,7 +29,7 @@ const supportsPassiveListeners = (() => {
 // Toggle event listener
 export function toggleListener(element, event, callback, toggle = false, passive = true, capture = false) {
     // Bail if no element, event, or callback
-    if (!is.element(element) || is.empty(event) || !is.function(callback)) {
+    if (!element || !('addEventListener' in element) || is.empty(event) || !is.function(callback)) {
         return;
     }
 


### PR DESCRIPTION
I broke this is #1030. Not all objects with event capabilities are actually elements.

Replaced with "duck-typing"