### PR TITLE
Suggestion: Remove array newline rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,9 +32,7 @@
                 "message": "Use local parameter instead."
             }
         ],
-        "no-param-reassign": [2, { "props": false }],
-        "array-bracket-newline": [2, { "minItems": 2 }],
-        "array-element-newline": [2, { "minItems": 2 }]
+        "no-param-reassign": [2, { "props": false }]
     },
     "parserOptions": {
         "sourceType": "module"

--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -48,10 +48,7 @@ const captions = {
                 const src = track.getAttribute('src');
                 const url = parseUrl(src);
 
-                if (url !== null && url.hostname !== window.location.href.hostname && [
-                    'http:',
-                    'https:',
-                ].includes(url.protocol)) {
+                if (url !== null && url.hostname !== window.location.href.hostname && ['http:', 'https:'].includes(url.protocol)) {
                     fetch(src, 'blob')
                         .then(blob => {
                             track.setAttribute('src', window.URL.createObjectURL(blob));
@@ -202,10 +199,9 @@ const captions = {
         const tracks = Array.from((this.media || {}).textTracks || []);
         // For HTML5, use cache instead of current tracks when it exists (if captions.update is false)
         // Filter out removed tracks and tracks that aren't captions/subtitles (for example metadata)
-        return tracks.filter(track => !this.isHTML5 || update || this.captions.meta.has(track)).filter(track => [
-            'captions',
-            'subtitles',
-        ].includes(track.kind));
+        return tracks
+            .filter(track => !this.isHTML5 || update || this.captions.meta.has(track))
+            .filter(track => ['captions', 'subtitles'].includes(track.kind));
     },
 
     // Get the current track for the current language

--- a/src/js/config/defaults.js
+++ b/src/js/config/defaults.js
@@ -89,15 +89,7 @@ const defaults = {
     // Speed default and options to display
     speed: {
         selected: 1,
-        options: [
-            0.5,
-            0.75,
-            1,
-            1.25,
-            1.5,
-            1.75,
-            2,
-        ],
+        options: [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
     },
 
     // Keyboard shortcut settings
@@ -151,11 +143,7 @@ const defaults = {
         'airplay',
         'fullscreen',
     ],
-    settings: [
-        'captions',
-        'quality',
-        'speed',
-    ],
+    settings: ['captions', 'quality', 'speed'],
 
     // Localisation
     i18n: {

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -580,10 +580,7 @@ const controls = {
 
         // Show/hide the tooltip
         // If the event is a moues in/out and percentage is inside bounds
-        if (is.event(event) && [
-            'mouseenter',
-            'mouseleave',
-        ].includes(event.type)) {
+        if (is.event(event) && ['mouseenter', 'mouseleave'].includes(event.type)) {
             toggle(event.type === 'mouseenter');
         }
     },
@@ -888,15 +885,7 @@ const controls = {
         if (is.array(options)) {
             this.options.speed = options;
         } else if (this.isHTML5 || this.isVimeo) {
-            this.options.speed = [
-                0.5,
-                0.75,
-                1,
-                1.25,
-                1.5,
-                1.75,
-                2,
-            ];
+            this.options.speed = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
         }
 
         // Set options if passed and filter based on config
@@ -1054,10 +1043,7 @@ const controls = {
             // Restore auto height/width
             const restore = e => {
                 // We're only bothered about height and width on the container
-                if (e.target !== container || ![
-                    'width',
-                    'height',
-                ].includes(e.propertyName)) {
+                if (e.target !== container || !['width', 'height'].includes(e.propertyName)) {
                     return;
                 }
 
@@ -1404,10 +1390,7 @@ const controls = {
         const replace = input => {
             let result = input;
 
-            Object.entries(props).forEach(([
-                key,
-                value,
-            ]) => {
+            Object.entries(props).forEach(([key, value]) => {
                 result = replaceAll(result, `{${key}}`, value);
             });
 
@@ -1455,16 +1438,9 @@ const controls = {
 
         // Setup tooltips
         if (this.config.tooltips.controls) {
-            const labels = getElements.call(
-                this,
-                [
-                    this.config.selectors.controls.wrapper,
-                    ' ',
-                    this.config.selectors.labels,
-                    ' .',
-                    this.config.classNames.hidden,
-                ].join(''),
-            );
+            const { classNames, selectors } = this.config;
+            const selector = `${selectors.controls.wrapper} ${selectors.labels} .${classNames.hidden}`;
+            const labels = getElements.call(this, selector);
 
             Array.from(labels).forEach(label => {
                 toggleClass(label, this.config.classNames.hidden, false);

--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -96,11 +96,7 @@ class Fullscreen {
 
         // Check for fullscreen support by vendor prefix
         let value = '';
-        const prefixes = [
-            'webkit',
-            'moz',
-            'ms',
-        ];
+        const prefixes = ['webkit', 'moz', 'ms'];
 
         prefixes.some(pre => {
             if (is.function(document[`${pre}ExitFullscreen`]) || is.function(document[`${pre}CancelFullScreen`])) {

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -23,10 +23,7 @@ const i18n = {
             '{title}': config.title,
         };
 
-        Object.entries(replace).forEach(([
-            key,
-            value,
-        ]) => {
+        Object.entries(replace).forEach(([key, value]) => {
             string = replaceAll(string, key, value);
         });
 

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -46,29 +46,7 @@ class Listeners {
         // Reset on keyup
         if (pressed) {
             // Which keycodes should we prevent default
-            const preventDefault = [
-                48,
-                49,
-                50,
-                51,
-                52,
-                53,
-                54,
-                56,
-                57,
-                32,
-                75,
-                38,
-                40,
-                77,
-                39,
-                37,
-                70,
-                67,
-                73,
-                76,
-                79,
-            ];
+            const preventDefault = [32, 37, 38, 39, 40, 48, 49, 50, 51, 52, 53, 54, 56, 57, 67, 70, 73, 75, 76, 77, 79];
 
             // Check focused element
             // and if the focused element is not editable (e.g. text input)
@@ -249,11 +227,7 @@ class Listeners {
             }
 
             // Show, then hide after a timeout unless another control event occurs
-            const show = [
-                'touchstart',
-                'touchmove',
-                'mousemove',
-            ].includes(event.type);
+            const show = ['touchstart', 'touchmove', 'mousemove'].includes(event.type);
 
             let delay = 0;
 
@@ -407,10 +381,8 @@ class Listeners {
 
         // Proxy events to container
         // Bubble up key events for Edge
-        on.call(this.player, this.player.media, this.player.config.events.concat([
-            'keyup',
-            'keydown',
-        ]).join(' '), event => {
+        const proxyEvents = this.player.config.events.concat(['keyup', 'keydown']).join(' ');
+        on.call(this.player, this.player.media, proxyEvents, event => {
             let {detail = {}} = event;
 
             // Get error details from media
@@ -572,11 +544,7 @@ class Listeners {
             const play = seek.hasAttribute('play-on-seeked');
 
             // Done seeking
-            const done = [
-                'mouseup',
-                'touchend',
-                'keyup',
-            ].includes(event.type);
+            const done = ['mouseup', 'touchend', 'keyup'].includes(event.type);
 
             // If we're done seeking and it was playing, resume playback
             if (play && done) {
@@ -651,10 +619,7 @@ class Listeners {
 
         // Update controls.pressed state (used for ui.toggleControls to avoid hiding when interacting)
         bind(this.player.elements.controls, 'mousedown mouseup touchstart touchend touchcancel', event => {
-            this.player.elements.controls.pressed = [
-                'mousedown',
-                'touchstart',
-            ].includes(event.type);
+            this.player.elements.controls.pressed = ['mousedown', 'touchstart'].includes(event.type);
         });
 
         // Focus in/out on controls

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -70,8 +70,8 @@ const vimeo = {
     // Set aspect ratio
     // For Vimeo we have an extra 300% height <div> to hide the standard controls and UI
     setAspectRatio(input) {
-        const ratio = is.string(input) ? input.split(':') : this.config.ratio.split(':');
-        const padding = 100 / ratio[0] * ratio[1];
+        const [x, y] = (is.string(input) ? input : this.config.ratio).split(':');
+        const padding = 100 / x * y;
         this.elements.wrapper.style.paddingBottom = `${padding}%`;
 
         if (this.supported.ui) {
@@ -294,10 +294,7 @@ const vimeo = {
         });
 
         // Set aspect ratio based on video size
-        Promise.all([
-            player.embed.getVideoWidth(),
-            player.embed.getVideoHeight(),
-        ]).then(dimensions => {
+        Promise.all([player.embed.getVideoWidth(), player.embed.getVideoHeight()]).then(dimensions => {
             const ratio = getAspectRatio(dimensions[0], dimensions[1]);
             vimeo.setAspectRatio.call(this, ratio);
         });

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -408,10 +408,7 @@ const youtube = {
                     // Reset timer
                     clearInterval(player.timers.playing);
 
-                    const seeked = player.media.seeking && [
-                        1,
-                        2,
-                    ].includes(event.data);
+                    const seeked = player.media.seeking && [1, 2].includes(event.data);
 
                     if (seeked) {
                         // Unset seeking and fire seeked event

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -172,10 +172,7 @@ class Plyr {
 
                     // Get attributes from URL and set config
                     if (url.searchParams.length) {
-                        const truthy = [
-                            '1',
-                            'true',
-                        ];
+                        const truthy = ['1', 'true'];
 
                         if (truthy.includes(url.searchParams.get('autoplay'))) {
                             this.config.autoplay = true;
@@ -682,12 +679,7 @@ class Plyr {
             return;
         }
 
-        let quality = ([
-            !is.empty(input) && Number(input),
-            this.storage.get('quality'),
-            config.selected,
-            config.default,
-        ]).find(is.number);
+        let quality = [!is.empty(input) && Number(input), this.storage.get('quality'), config.selected, config.default].find(is.number);
 
         if (!options.includes(quality)) {
             const value = closest(options, quality);

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -212,10 +212,7 @@ const ui = {
 
     // Check if media is loading
     checkLoading(event) {
-        this.loading = [
-            'stalled',
-            'waiting',
-        ].includes(event.type);
+        this.loading = ['stalled', 'waiting'].includes(event.type);
 
         // Clear timer
         clearTimeout(this.timers.loading);

--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -42,10 +42,7 @@ export function setAttributes(element, attributes) {
         return;
     }
 
-    Object.entries(attributes).forEach(([
-        key,
-        value,
-    ]) => {
+    Object.entries(attributes).forEach(([key, value]) => {
         element.setAttribute(key, value);
     });
 }

--- a/src/js/utils/urls.js
+++ b/src/js/utils/urls.js
@@ -30,10 +30,7 @@ export function buildUrlParams(input) {
     const params = new URLSearchParams();
 
     if (is.object(input)) {
-        Object.entries(input).forEach(([
-            key,
-            value,
-        ]) => {
+        Object.entries(input).forEach(([key, value]) => {
             params.set(key, value);
         });
     }


### PR DESCRIPTION
Removed the eslint rules that forces newlines within arrays, since the rules make some otherwise valid and practical code such as `Object.entries(([key, value]) => ...)`, `[x, y].includes(z)` and array destructuring much less practical.

`{"minItems": 2}` suggests the code samples should be permitted, but eslint still rejects them. Even with it though, I personally think `const preventDefault = [32, 37, 38, 39, 40, 48, 49, 50, 51, 52, 53, 54, 56, 57, 67, 70, 73, 75, 76, 77, 79];` is a lot more convenient than one line per keycode for example.

Also removed the current newlines in arrays. Running `prettier` with `--write` using the conf does this too actually, so unless this is only happening for me locally(?) the rules were conflicting with each other too.

Hopefully you agree. If not this can be rejected. There are no functional changes.