### PR TITLE
Captions fixes (again)

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -7,7 +7,7 @@ import controls from './controls';
 import i18n from './i18n';
 import support from './support';
 import browser from './utils/browser';
-import { createElement, emptyElement, getAttributesFromSelector, insertAfter, removeElement, toggleClass } from './utils/elements';
+import { createElement, emptyElement, getAttributesFromSelector, insertAfter, removeElement, toggleClass, toggleState } from './utils/elements';
 import { on, triggerEvent } from './utils/events';
 import fetch from './utils/fetch';
 import is from './utils/is';
@@ -125,6 +125,28 @@ const captions = {
         // Update available languages in list
         if ((this.config.controls || []).includes('settings') && this.config.settings.includes('captions')) {
             controls.setCaptionsMenu.call(this);
+        }
+    },
+
+    toggle(input) {
+        // If there's no full support
+        if (!this.supported.ui) {
+            return;
+        }
+
+        // If the method is called without parameter, toggle based on current value
+        const active = is.boolean(input) ? input : !this.elements.container.classList.contains(this.config.classNames.captions.active);
+
+        // Toggle state
+        toggleState(this.elements.buttons.captions, active);
+
+        // Add class hook
+        toggleClass(this.elements.container, this.config.classNames.captions.active, active);
+
+        // Update state and trigger event
+        if (active !== this.captions.active) {
+            this.captions.active = active;
+            triggerEvent.call(this, this.media, this.captions.active ? 'captionsenabled' : 'captionsdisabled');
         }
     },
 

--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -128,6 +128,7 @@ const captions = {
         }
     },
 
+    // Used internally for toggleCaptions()
     toggle(input) {
         // If there's no full support
         if (!this.supported.ui) {
@@ -146,10 +147,19 @@ const captions = {
         // Update state and trigger event
         if (active !== this.captions.active) {
             this.captions.active = active;
-            triggerEvent.call(this, this.media, this.captions.active ? 'captionsenabled' : 'captionsdisabled');
+
+            // Update UI
+            controls.updateSetting.call(this, 'captions');
+
+            // Save to storage
+            this.storage.set({ captions: active });
+
+            // Trigger event (not used internally)
+            triggerEvent.call(this, this.media, active ? 'captionsenabled' : 'captionsdisabled');
         }
     },
 
+    // Used internally for currentTrack setter
     set(index, setLanguage = true, show = true) {
         const tracks = captions.getTracks.call(this);
 
@@ -187,7 +197,13 @@ const captions = {
                 this.embed.enableTextTrack(language);
             }
 
-            // Trigger event
+            // Update UI
+            controls.updateSetting.call(this, 'captions');
+
+            // Save to storage
+            this.storage.set({ language });
+
+            // Trigger event (not used internally)
             triggerEvent.call(this, this.media, 'languagechange');
         }
 
@@ -202,6 +218,7 @@ const captions = {
         }
     },
 
+    // Used internally for language setter
     setLanguage(language, show = true) {
         if (!is.string(language)) {
             this.debug.warn('Invalid language argument', language);

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -10,7 +10,7 @@ import { repaint, transitionEndEvent } from './utils/animation';
 import { dedupe } from './utils/arrays';
 import browser from './utils/browser';
 import { createElement, emptyElement, getAttributesFromSelector, getElement, getElements, hasClass, removeElement, setAttributes, toggleClass, toggleHidden, toggleState } from './utils/elements';
-import { once } from './utils/events';
+import { on, off } from './utils/events';
 import is from './utils/is';
 import loadSprite from './utils/loadSprite';
 import { extend } from './utils/objects';
@@ -1026,7 +1026,7 @@ const controls = {
             return;
         }
 
-        // Are we targetting a tab? If not, bail
+        // Are we targeting a tab? If not, bail
         const isTab = pane.getAttribute('role') === 'tabpanel';
         if (!isTab) {
             return;
@@ -1065,10 +1065,12 @@ const controls = {
                 container.style.width = '';
                 container.style.height = '';
 
+                // Only listen once
+                off.call(this, container, transitionEndEvent, restore);
             };
 
             // Listen for the transition finishing and restore auto height/width
-            once.call(this, container, transitionEndEvent, restore);
+            on.call(this, container, transitionEndEvent, restore);
 
             // Set dimensions to target
             container.style.width = `${size.width}px`;

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -848,7 +848,7 @@ const controls = {
         // Generate options data
         const options = tracks.map((track, value) => ({
             value,
-            checked: this.captions.active && this.currentTrack === value,
+            checked: this.captions.toggled && this.currentTrack === value,
             title: captions.getLabel.call(this, track),
             badge: track.language && controls.createBadge.call(this, track.language.toUpperCase()),
             list,
@@ -858,7 +858,7 @@ const controls = {
         // Add the "Disabled" option to turn off captions
         options.unshift({
             value: -1,
-            checked: !this.captions.active,
+            checked: !this.captions.toggled,
             title: i18n.get('disabled', this.config),
             list,
             type: 'language',

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -387,24 +387,6 @@ class Listeners {
             controls.updateSetting.call(this.player, 'quality', null, event.detail.quality);
         });
 
-        // Caption language change
-        on.call(this.player, this.player.media, 'languagechange', () => {
-            // Update UI
-            controls.updateSetting.call(this.player, 'captions');
-
-            // Save to storage
-            this.player.storage.set({ language: this.player.language });
-        });
-
-        // Captions toggle
-        on.call(this.player, this.player.media, 'captionsenabled captionsdisabled', () => {
-            // Update UI
-            controls.updateSetting.call(this.player, 'captions');
-
-            // Save to storage
-            this.player.storage.set({ captions: this.player.captions.active });
-        });
-
         // Proxy events to container
         // Bubble up key events for Edge
         on.call(this.player, this.player.media, this.player.config.events.concat([

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -459,7 +459,7 @@ class Listeners {
         );
 
         // Captions toggle
-        bind(this.player.elements.buttons.captions, 'click', this.player.toggleCaptions);
+        bind(this.player.elements.buttons.captions, 'click', () => this.player.toggleCaptions());
 
         // Fullscreen toggle
         bind(

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -833,7 +833,7 @@ class Plyr {
      * @param {boolean} input - Whether to enable captions
      */
     toggleCaptions(input) {
-        captions.toggle.call(this, input);
+        captions.toggle.call(this, input, false);
     }
 
     /**
@@ -841,15 +841,15 @@ class Plyr {
      * @param {number} - Caption index
      */
     set currentTrack(input) {
-        captions.set.call(this, input);
+        captions.set.call(this, input, false);
     }
 
     /**
      * Get the current caption track index (-1 if disabled)
      */
     get currentTrack() {
-        const { active, currentTrack } = this.captions;
-        return active ? currentTrack : -1;
+        const { toggled, currentTrack } = this.captions;
+        return toggled ? currentTrack : -1;
     }
 
     /**
@@ -858,7 +858,7 @@ class Plyr {
      * @param {string} - Two character ISO language code (e.g. EN, FR, PT, etc)
      */
     set language(input) {
-        captions.setLanguage.call(this, input);
+        captions.setLanguage.call(this, input, false);
     }
 
     /**

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -19,7 +19,7 @@ import Storage from './storage';
 import support from './support';
 import ui from './ui';
 import { closest } from './utils/arrays';
-import { createElement, hasClass, removeElement, replaceElement, toggleClass, toggleState, wrap } from './utils/elements';
+import { createElement, hasClass, removeElement, replaceElement, toggleClass, wrap } from './utils/elements';
 import { off, on, once, triggerEvent, unbindListeners } from './utils/events';
 import is from './utils/is';
 import loadSprite from './utils/loadSprite';
@@ -833,25 +833,7 @@ class Plyr {
      * @param {boolean} input - Whether to enable captions
      */
     toggleCaptions(input) {
-        // If there's no full support
-        if (!this.supported.ui) {
-            return;
-        }
-
-        // If the method is called without parameter, toggle based on current value
-        const active = is.boolean(input) ? input : !this.elements.container.classList.contains(this.config.classNames.captions.active);
-
-        // Toggle state
-        toggleState(this.elements.buttons.captions, active);
-
-        // Add class hook
-        toggleClass(this.elements.container, this.config.classNames.captions.active, active);
-
-        // Update state and trigger event
-        if (active !== this.captions.active) {
-            this.captions.active = active;
-            triggerEvent.call(this, this.media, this.captions.active ? 'captionsenabled' : 'captionsdisabled');
-        }
+        captions.toggle.call(this, input);
     }
 
     /**


### PR DESCRIPTION
Fixes a caveat mentioned in the rewrite from last time, and some related issues including the issue with `captions.active` not being respected when using the `source` setter (as can be seen with Vimeo on the demo page).

The main problem was that the events listening to caption changes was setting this to localStorage, so when `source` is first soft-`destroy`ing the old dom, the tracks are all removed. The update handler would (rightfully) then toggle captions off, which in turn was (not rightfully) saved to localStorage. Then when the new source is created, the setting was read from localStorage and since it said `active` was `false`, so the new source would have captions toggled off.

This was solved by added a `passive` flag (default: `true`) to internal captions methods

* Used to avoid overriding user preferences, when the user didn't intend this. For example updating state because of the available tracks changing, or setting it initially.
* The public API (`.language = ...`, `.currentTrack = ...` and `.toggleCaptions()`) wraps the internal methods but forces passive to `false`. When using the public API, this is regarded as the user's intention, so user preferences (localStorage and the internal state representing user preferences) is updated.
* Captions will be toggled off regardless of `captions.active` when the requested language doesn't have a match, until either:
  * A matching track is added (when `captions.update` is `true`)
  * User picks a track / language by the public API or using the menu.
  * User toggles captions on using the button or `.toggleCaptions()`. The is the only time a language will be "forced" to show even if there isn't any matching the preferred language. The logic for this was improved to match the tracks with all browser languages, in case the user is multilingual.

Also fixed the `transitionend` event listener, which was recently broken, making the menus stay at a fixed height and width, and as a result adding tracks while the menu pane is open didn't work (the new option was "cropped").