### PR TITLE
Small captions fixes

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -156,6 +156,12 @@ const captions = {
 
         // Update state and trigger event
         if (active !== toggled) {
+            // When passive, don't override user preferences
+            if (!passive) {
+                this.captions.active = active;
+                this.storage.set({ captions: active });
+            }
+
             // Force language if the call isn't passive and there is no matching language to toggle to
             if (!this.language && active && !passive) {
                 const tracks = captions.getTracks.call(this);
@@ -182,12 +188,6 @@ const captions = {
 
             // Update settings menu
             controls.updateSetting.call(this, 'captions');
-
-            // When passive, don't override user preferences
-            if (!passive) {
-                this.captions.active = active;
-                this.storage.set({ captions: active });
-            }
 
             // Trigger event (not used internally)
             triggerEvent.call(this, this.media, active ? 'captionsenabled' : 'captionsdisabled');
@@ -241,13 +241,13 @@ const captions = {
             triggerEvent.call(this, this.media, 'languagechange');
         }
 
+        // Show captions
+        captions.toggle.call(this, true, passive);
+
         if (this.isHTML5 && this.isVideo) {
             // If we change the active track while a cue is already displayed we need to update it
             captions.updateCues.call(this);
         }
-
-        // Show captions
-        captions.toggle.call(this, true, passive);
     },
 
     // Set captions by language

--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -71,7 +71,7 @@ const captions = {
         const languages = dedupe(Array.from(navigator.languages || navigator.userLanguage)
             .map(language => language.split('-')[0]));
 
-        let language = this.storage.get('language') || this.config.captions.language;
+        let language = (this.storage.get('language') || this.config.captions.language || 'auto').toLowerCase();
 
         // Use first browser language when language is 'auto'
         if (language === 'auto') {
@@ -252,13 +252,14 @@ const captions = {
 
     // Set captions by language
     // Used internally for the language setter with the passive option forced to false
-    setLanguage(language, passive = true) {
-        if (!is.string(language)) {
-            this.debug.warn('Invalid language argument', language);
+    setLanguage(input, passive = true) {
+        if (!is.string(input)) {
+            this.debug.warn('Invalid language argument', input);
             return;
         }
         // Normalize
-        this.captions.language = language.toLowerCase();
+        const language = input.toLowerCase();
+        this.captions.language = language;
 
         // Set currentTrack
         const tracks = captions.getTracks.call(this);


### PR DESCRIPTION
* Re-add lowercasing language input (and also fallback on `auto` if someone sets the language to an empty string via config).
* Fix issue with toggling not showing the new track and storing the new value when forcing a language.

Sorry these slipped my attention while testing.