### PR TITLE
Fix poster race conditions

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -119,8 +119,11 @@ const vimeo = {
         iframe.setAttribute('allowtransparency', '');
         iframe.setAttribute('allow', 'autoplay');
 
+        // Get poster, if already set
+        const { poster } = player;
+
         // Inject the package
-        const wrapper = createElement('div', { class: player.config.classNames.embedContainer });
+        const wrapper = createElement('div', { poster, class: player.config.classNames.embedContainer });
         wrapper.appendChild(iframe);
         player.media = replaceElement(wrapper, player.media);
 

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -140,7 +140,7 @@ const vimeo = {
             url.pathname = `${url.pathname.split('_')[0]}.jpg`;
 
             // Set and show poster
-            ui.setPoster.call(player, url.href);
+            ui.setPoster.call(player, url.href).catch(() => {});
         });
 
         // Setup instance

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -166,7 +166,7 @@ const youtube = {
         const container = createElement('div', { id, poster });
         player.media = replaceElement(container, player.media);
 
-        // Set poster image
+        // Id to poster wrapper
         const posterSrc = format => `https://img.youtube.com/vi/${videoId}/${format}default.jpg`;
 
         // Check thumbnail images in order of quality, but reject fallback thumbnails (120px wide)
@@ -179,7 +179,8 @@ const youtube = {
                 if (!posterSrc.includes('maxres')) {
                     player.elements.poster.style.backgroundSize = 'cover';
                 }
-            });
+            })
+            .catch(() => {});
 
         // Setup instance
         // https://developers.google.com/youtube/iframe_api_reference

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -158,7 +158,12 @@ const youtube = {
         // Replace the <iframe> with a <div> due to YouTube API issues
         const videoId = parseId(source);
         const id = generateId(player.provider);
-        const container = createElement('div', { id });
+
+        // Get poster, if already set
+        const { poster } = player;
+
+        // Replace media element
+        const container = createElement('div', { id, poster });
         player.media = replaceElement(container, player.media);
 
         // Set poster image

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -790,7 +790,7 @@ class Plyr {
             return;
         }
 
-        ui.setPoster.call(this, input);
+        ui.setPoster.call(this, input, false).catch(() => {});
     }
 
     /**

--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -42,9 +42,11 @@ export function setAttributes(element, attributes) {
         return;
     }
 
-    Object.entries(attributes).forEach(([key, value]) => {
-        element.setAttribute(key, value);
-    });
+    // Assume null and undefined attributes should be left out,
+    // Setting them would otherwise convert them to "null" and "undefined"
+    Object.entries(attributes)
+        .filter(([, value]) => !is.nullOrUndefined(value))
+        .forEach(([key, value]) => element.setAttribute(key, value));
 }
 
 // Create a DocumentFragment

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -111,3 +111,9 @@ export function unbindListeners() {
         this.eventListeners = [];
     }
 }
+
+// Run method when / if player is ready
+export function ready () {
+    return new Promise(resolve => this.ready ? setTimeout(resolve, 0) : on.call(this, this.elements.container, 'ready', resolve))
+        .then(() => {});
+}


### PR DESCRIPTION
Initial step for #1018

* Filter out `null` and `undefined` values in `elements.setAttributes()`, since they would otherwise be set as strings.
* Copy the `poster` property when replacing the media element in vimeo and youtube (which is also why the change above was made).
* Add `passive` option to internal `ui.setPoster()` method (like with captions).
* Fix race conditions: Make `ui.setPoster()` set the poster attribute synchronously, but apply it to the dom async, and invalidate if the actual update if the attribute has been changed.
* Also added a `ready` promise in events.js that is used to wrap setPoster so it doesn't trigger too soon.

I'm pretty sure this needs revisiting. I noticed some quirks, but not directly related to or introduced by this PR.