### PR TITLE
Fix captions.toggle() if there is no toggle button

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -191,8 +191,10 @@ const captions = {
                 return;
             }
 
-            // Toggle state
-            this.elements.buttons.captions.pressed = active;
+            // Toggle button if it's enabled
+            if (this.elements.buttons.captions) {
+                this.elements.buttons.captions.pressed = active;
+            }
 
             // Add class hook
             toggleClass(this.elements.container, activeClass, active);


### PR DESCRIPTION
`.toggleCaptions()` (internally `captions.toggle()`) currently expects a toggle button.


It might not exist, in which case toggling should still be possible. This PR fixes that.