### PR TITLE
Handle undefined this.player.elements.buttons.play

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -431,9 +431,11 @@ class Listeners {
         };
 
         // Play/pause toggle
-        Array.from(this.player.elements.buttons.play).forEach(button => {
-            bind(button, 'click', this.player.togglePlay, 'play');
-        });
+        if (this.player.elements.buttons.play) {
+            Array.from(this.player.elements.buttons.play).forEach(button => {
+                bind(button, 'click', this.player.togglePlay, 'play');
+            });
+        }
 
         // Pause
         bind(this.player.elements.buttons.restart, 'click', this.player.restart, 'restart');


### PR DESCRIPTION
### Handle undefined this.player.elements.buttons.play

I'm getting a `TypeError: Cannot convert undefined or null to object` when I try to configure a player without a `play-large` and `play` control.  I haven't had a chance to research why this doesn't happen in the demo, but can do so if you'd like more details. 

The value of `this.player.elements.buttons` at the time of execution is `{mute: button.plyr__control, fullscreen: button.plyr__control}`.  The `play` property is undefined and causes a TypeError when passed to `Array.from`.

My player configuration looks like this. 

```
class MyPlayer extends React.Component<Props> {
  constructor() {
    super();
    this.playerRef = React.createRef();
  }

  componentDidMount() {
    this.player = new Plyr(this.playerRef.current, {
      controls: ['airplay', 'fullscreen', 'mute', 'pip', 'volume'],
    });
  }

  render() {
    const { video } = this.props;
    return (
      <video
        controls={true}
        id="player"
        poster={video.thumbnailUrl}
        preload="auto"
        ref={this.playerRef}
        src={video.url}
      />
    );
  }
}
```

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
