### PR TITLE
Hide currentTime and progress

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -633,6 +633,16 @@ const controls = {
             return;
         }
 
+        // If duration is the 2**32 (shaka), Infinity (HLS), DASH-IF (Number.MAX_SAFE_INTEGER || Number.MAX_VALUE) indicating live we hide the currentTime and progressbar.
+        // https://github.com/video-dev/hls.js/blob/5820d29d3c4c8a46e8b75f1e3afa3e68c1a9a2db/src/controller/buffer-controller.js#L415
+        // https://github.com/google/shaka-player/blob/4d889054631f4e1cf0fbd80ddd2b71887c02e232/lib/media/streaming_engine.js#L1062
+        // https://github.com/Dash-Industry-Forum/dash.js/blob/69859f51b969645b234666800d4cb596d89c602d/src/dash/models/DashManifestModel.js#L338
+        if (this.duration >= 2**32) {
+            toggleHidden(this.elements.display.currentTime, true);
+            toggleHidden(this.elements.progress, true);
+            return;
+        }
+
         // Update ARIA values
         if (is.element(this.elements.inputs.seek)) {
             this.elements.inputs.seek.setAttribute('aria-valuemax', this.duration);

--- a/src/sass/components/controls.scss
+++ b/src/sass/components/controls.scss
@@ -12,6 +12,7 @@
     align-items: center;
     display: flex;
     text-align: center;
+    justify-content: flex-end;
 
     // Spacing
     > .plyr__control,
@@ -22,7 +23,7 @@
 
         &:first-child,
         &:first-child + [data-plyr='pause'] {
-            margin-left: 0;
+            margin-right: auto;
         }
     }
 


### PR DESCRIPTION
### Link to related issue (if applicable)
1072
### Summary of proposed changes
Hide current time and progress bar when playing live streams
