### PR TITLE
Improve flexibility of quality selector

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -723,6 +723,7 @@ const controls = {
                 label = i18n.get(`qualityBadge.${quality.label}`, this.config);
 
                 if (!label.length) {
+                    // TODO: Try to find a badge based on height
                     return null;
                 }
             }
@@ -754,23 +755,19 @@ const controls = {
 
     // Translate a value into a nice label
     getLabel(setting, value, defaultLabel) {
+        let label;
         switch (setting) {
             case 'speed':
                 return value === 1 ? i18n.get('normal', this.config) : `${value}&times;`;
 
             case 'quality':
-                if (is.number(value)) {
-                    const label = i18n.get(`qualityLabel.${value}`, this.config);
+                label = i18n.get(`qualityLabel.${value}`, this.config);
 
-                    // If we don't find a valid label, we return passed in defaultLabel
-                    if (!label.length) {
-                        return defaultLabel;
-                    }
-
-                    return label;
+                // If we don't find a valid label, we return passed in defaultLabel
+                if (!label.length) {
+                    return defaultLabel || toTitleCase(value);
                 }
-                return defaultLabel || toTitleCase(value);
-
+                return label;
             case 'captions':
                 return captions.getLabel.call(this);
 

--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -21,10 +21,15 @@ const html5 = {
     // Get quality levels
     getQualityOptions() {
         // Get sizes from <source> elements
-        return html5.getSources
+        const sizes = html5.getSources
             .call(this)
             .map(source => Number(source.getAttribute('size')))
             .filter(Boolean);
+        return sizes.map((size, index) => ({
+            label: `${size}`,
+            height: size,
+            index,
+        }));
     },
 
     extend() {
@@ -35,21 +40,26 @@ const html5 = {
         const player = this;
 
         // Quality
+        const qualityLevels = html5.getQualityOptions.call(player);
         Object.defineProperty(player.media, 'quality', {
             get() {
                 // Get sources
                 const sources = html5.getSources.call(player);
                 const source = sources.find(source => source.getAttribute('src') === player.source);
+                if (!source) {
+                    return undefined;
+                }
+                const sourceIndex = sources.indexOf(source);
 
-                // Return size, if match is found
-                return source && Number(source.getAttribute('size'));
+                // Return label, if match is found
+                return qualityLevels[sourceIndex].label;
             },
             set(input) {
                 // Get sources
                 const sources = html5.getSources.call(player);
 
                 // Get first match for requested size
-                const source = sources.find(source => Number(source.getAttribute('size')) === input);
+                const source = sources.find(source => source.getAttribute('size') === input.label);
 
                 // No matching source found
                 if (!source) {

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -376,7 +376,7 @@ class Listeners {
         // Quality change
         on.call(this.player, this.player.media, 'qualitychange', event => {
             // Update UI
-            controls.updateSetting.call(this.player, 'quality', null, event.detail.quality);
+            controls.updateSetting.call(this.player, 'quality', null, event.detail.quality.label);
         });
 
         // Proxy events to container
@@ -511,7 +511,10 @@ class Listeners {
                 proxy(
                     event,
                     () => {
-                        this.player.quality = event.target.value;
+                        this.player.quality = {
+                            label: event.target.value,
+                            index: Number(event.target.attributes.index.value),
+                        };
                         showHomeTab();
                     },
                     'quality',

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -51,7 +51,14 @@ function mapQualityUnits(levels) {
         return levels;
     }
 
-    return dedupe(levels.map(level => mapQualityUnit(level)));
+    const mappedLevels = dedupe(levels.map(level => mapQualityUnit(level)));
+    const result = mappedLevels.map((level, index) => ({
+        label: levels[index],
+        index,
+        height: level,
+        badge: level >= 720 ? 'HD' : 'SD',
+    }));
+    return result;
 }
 
 // Set playback state and trigger change (only on actual change)
@@ -300,7 +307,13 @@ const youtube = {
                             return mapQualityUnit(instance.getPlaybackQuality());
                         },
                         set(input) {
-                            instance.setPlaybackQuality(mapQualityUnit(input));
+                            let label;
+                            if (input instanceof String) {
+                                label = input;
+                            } else if (input instanceof Object) {
+                                label = input.label;
+                            }
+                            instance.setPlaybackQuality(mapQualityUnit(label));
                         },
                     });
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -677,21 +677,30 @@ class Plyr {
         const config = this.config.quality;
         const options = this.options.quality;
 
+        let quality;
         if (!options.length) {
             return;
         }
 
-        let quality = [
-            !is.empty(input) && Number(input),
-            this.storage.get('quality'),
-            config.selected,
-            config.default,
-        ].find(is.number);
+        if (input instanceof String) {
+            // We have only a label
+            // Convert this into an Object of the expected type
+            quality = {
+                value: input,
+            };
+        } else if (input instanceof Object) {
+            quality = input;
+        } else {
+            this.debug.warn(`Quality option of unknown type: ${input} (${typeof input}). Ignoring`);
+            return;
+        }
 
-        if (!options.includes(quality)) {
-            const value = closest(options, quality);
-            this.debug.warn(`Unsupported quality option: ${quality}, using ${value} instead`);
-            quality = value;
+        // Get the corresponding quality listing from options
+        const entry = options.find((level) => level.label === quality.label && (quality.index ? level.index === quality.index : true));
+
+        if (!entry) {
+            this.debug.warn(`Unsupported quality option: ${input}. Ignoring`);
+            return;
         }
 
         // Trigger request event


### PR DESCRIPTION
I would like some feedback on this PR. If you use Plyr and you care about the quality setting, please have a read and provide feedback.

### Link to related issue (if applicable)
This is related to #878 and also PR #988

### Summary of proposed changes
- All providers specify the following for each quality level
  - label: String _mandatory_ (This is what shows up in the menu. Solves #878)
  - height: Number _mandatory_ (Used to determine badge if badge isn't specified)
  - index: Number _optional_
  - badge: String _optional_

The 'index' field is optional and is used to resolve conflicts. An example of where this may come in handy is provided below.

Finally, the badge field allows the provider to explicitly specify a badge for a particular quality level. This is somewhat a double-edged sword. On one hand, this gives full freedom to providers to determine the badges for each quality level. On the other, it may lead to inconsistencies where one provider reports `HD` for a video with height of 720 whereas another provider does not.

Imagine a scenario where the available quality levels are as follows:
```
{width: 422, height: 180, bitrate: 258157}
{width: 638, height: 272, bitrate: 520929}
{width: 638, height: 272, bitrate: 831270}
{width: 958, height: 408, bitrate: 1144430}
{width: 1277, height: 554, bitrate: 1558322}
{width: 1921, height: 818, bitrate: 4149264}
{width: 1921, height: 818, bitrate: 6214307}
{width: 4096, height: 1744, bitrate: 10285391}
```

In the above example, with the current implementation, the only attribute that is passed on to the provider on `qualityrequested` is `value`. If the provider implemented this similar to how YouTube is currently implemented (purely based on height), then, there would be two quality entries with the same `value`. My hope is that the index field will help with resolution in such cases by telling the provider exactly which quality element was selected.

Even after #988 has been merged in, the quality badge relies heavily on some hard-coded values. If a video presents a quality value that is not found in [480, 576, 720, 1080, 1440, 2160], then no badge is provided. In the above example, _none_ of the entries would get a badge (if the `value` was determined by height).   
Instead, this PR allows providers to explicitly specify a badge of their choice. We could also add some fallback logic where the 'height' attribute is used to determine the badge.

Here's a [pen] that shows the results for HTML5/HLS/YouTube.
### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build from the PR
- [ ] Ensure PR makes sense with regard to `i18n`
- [ ] Figure out how to solve initial quality on HTML5 videos (currently shows `undefined`)
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
