### PR TITLE
Gitignore yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ aws.json
 !dist/blank.mp4
 index-*.html
 npm-debug.log
-*.webm
+yarn-error.log
 package-lock.json
+*.webm
 .idea/


### PR DESCRIPTION
yarn-error.log is generated on lint errors among others (so quite frequently now) if you run npm scripts via `yarn`. It shouldn't be added.