### PR TITLE
Add navigator.languages fallback for ios 9

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -84,7 +84,7 @@ const captions = {
         // * toggled:   The real captions state
 
         const languages = dedupe(
-            Array.from(navigator.languages || navigator.userLanguage).map(language => language.split('-')[0]),
+            Array.from(navigator.languages || navigator.language || navigator.userLanguage).map(language => language.split('-')[0]),
         );
 
         let language = (this.storage.get('language') || this.config.captions.language || 'auto').toLowerCase();


### PR DESCRIPTION
Restore `navigator.language` as a fallback for `navigator.languages`, because of reports of ios 9 only supporting the singular variant (#1085).


I can't test this myself.