### PR TITLE
Add support for YouTube's hl param

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Plyr extends upon the standard [HTML5 media element](https://developer.mozilla.o
 </audio>
 ```
 
-For YouTube and Vimeo players, Plyr uses progressive enhancement to enhance the default `<iframe>` embeds. Below are some examples. The `plyr__video-embed` classname will make the embed responsive. You can add the `autoplay`, `loop` and `playsinline` (YouTube only) query parameters to the URL and they will be set as config options automatically. For YouTube, the `origin` should be updated to reflect the domain you're hosting the embed on, or you can opt to omit it.
+For YouTube and Vimeo players, Plyr uses progressive enhancement to enhance the default `<iframe>` embeds. Below are some examples. The `plyr__video-embed` classname will make the embed responsive. You can add the `autoplay`, `loop`, `hl` (YouTube only) and `playsinline` (YouTube only) query parameters to the URL and they will be set as config options automatically. For YouTube, the `origin` should be updated to reflect the domain you're hosting the embed on, or you can opt to omit it.
 
 #### YouTube embed
 

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -188,6 +188,7 @@ const youtube = {
             videoId,
             playerVars: {
                 autoplay: player.config.autoplay ? 1 : 0, // Autoplay
+                hl: player.config.hl, // iframe interface language
                 controls: player.supported.ui ? 0 : 1, // Only show controls if not fully supported
                 rel: 0, // No related vids
                 showinfo: 0, // Hide info

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -171,7 +171,7 @@ class Plyr {
                     this.elements.container.className = '';
 
                     // Get attributes from URL and set config
-                    if (url.searchParams.length) {
+                    if (url.search.length) {
                         const truthy = ['1', 'true'];
 
                         if (truthy.includes(url.searchParams.get('autoplay'))) {
@@ -185,6 +185,7 @@ class Plyr {
                         // YouTube requires the playsinline in the URL
                         if (this.isYouTube) {
                             this.config.playsinline = truthy.includes(url.searchParams.get('playsinline'));
+                            this.config.hl = url.searchParams.get('hl');
                         } else {
                             this.config.playsinline = true;
                         }


### PR DESCRIPTION
### Link to related issue
#1119 

### Summary of proposed changes
Added support for YouTube's `hl` param, which allows setting the player's interface language.

While adding it, I noticed Plyr uses `url.searchParams.length` to check if there are any params in the URL. Since `searchParams` is an iterator, the `length` property doesn't exist, so this check always return false. I changed it to use `url.search` which returns a string version of all parameters (or an empty string).

#### Before
![image](https://user-images.githubusercontent.com/617989/43165186-534fe3a8-8f61-11e8-9d69-f4b301538329.png)

#### After (using `hl=fr`)
![image](https://user-images.githubusercontent.com/617989/43165269-7e1066da-8f61-11e8-9300-3d1fde9ffac3.png)

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
