### PR TITLE
Added rich Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔
+
+---
+*Please _use this issue template_ as it makes replicating and fixing the issue easier for us. If you decide not to use it or you are vague your issue may be close instantly.*
+
+### Expected behaviour
+
+### Actual behaviour
+
+### Environment
+
+- Browser:
+- Version:
+- Operating System:
+- Version:
+
+### Steps to reproduce
+-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: 🚀 Feature Request
+about: A suggestion for a new feature ✨
+
+---
+
+### Feature Request
+
+#### Motivation Behind Feature
+<!-- Why should this feature be implemented? What problem does it solve? -->
+
+#### Feature Description
+<!-- Describe your feature request in detail -->
+<!-- Please provide any code examples or screenshots of what this feature would look like -->
+<!-- Are there any drawbacks? Will this break anything for existing users? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,18 @@
+---
+name: ❓ Support Question
+about: Not sure how something works or how to implement some functionality? Ask us here! (But please read the entire README first 🙃)
+
+---
+
+### Question Checklist
+<!-- Be sure to mark these items with an 'x' to prove you did your homework. It should be like [x] (not [ x] or [x ]) -->
+- [ ] Updated Plyr to the latest version
+- [ ] I read [the README](https://github.com/jaydrogers/plyr/blob/master/readme.md)
+- [ ] I searched for [existing GitHub issues](https://github.com/sampotts/plyr/issues)
+
+### Question Subject
+<!-- What do you have a question about? -->
+<!-- Is this a question about documentation? -->
+
+#### Question Description
+<!-- Please include expected behaviour and any relevant code samples with your question if possible -->


### PR DESCRIPTION
### Summary of proposed changes
- Created rich Github templates for different categories of issues ([see my fork](https://github.com/jaydrogers/plyr/issues) and open a new issue for a demo)
- This will help channel people correctly based on their question
- Supports bug reports, support questions, and feature requests
- Written in British English (now isn't that good behaviour! 😀)

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)

### Other possible extenstions

1. Under the `Environment` headline on a bug report (`.github/ISSUE_TEMPLATE/bug_report.md`), we could have the user just provide their "support link" that is generated on https://www.whatsmybrowser.org/. Example of what we could say:
```
#### Environment

<!-- If you have privacy concerns about using What's My Browser, at least copy and paste the contents and remove your IP address -->
- [What's My Browser Support](https://www.whatsmybrowser.org/) link: < paste link here
- Plyr Version:
```

I cannot take credit for the creative emojis. I actually "borrowed" this from @KrauseFX and his awesome work with https://fastlane.tools/ 🤓

Thanks for your awesome work @sampotts! Let me know your thoughts if there needs to be any more changes. 👍
