### PR TITLE
Make sure youtube.onReady doesn't run twice

### DIFF
--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -239,6 +239,10 @@ const youtube = {
                     triggerEvent.call(player, player.media, 'ratechange');
                 },
                 onReady(event) {
+                    // Bail if onReady has already been called. See issue #1108
+                    if (is.function(player.media.play)) {
+                        return;
+                    }
                     // Get the instance
                     const instance = event.target;
 


### PR DESCRIPTION
### Link to related issue (if applicable)

#1108

### Summary of proposed changes
Adds a condition to youtube.onReady and bails if it has already been run (checking if it has `play`).

I haven't actually been able to replicate #1108, so I can't test that this works (only that it doesn't break). It should work, but in case the real issue (onReady being called twice) is also caused by our code, this is not an optimal fix.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
