### PR TITLE
Hide empty controls

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1455,12 +1455,9 @@ const controls = {
             target = this.elements.container;
         }
 
-        // Inject controls HTML
-        if (is.element(container)) {
-            target.appendChild(container);
-        } else if (container) {
-            target.insertAdjacentHTML('beforeend', container);
-        }
+        // Inject controls HTML (needs to be before captions, hence "afterbegin")
+        const insertMethod = is.element(container) ? 'insertAdjacentElement' : 'insertAdjacentHTML';
+        target[insertMethod]('afterbegin', container);
 
         // Find the elements if need be
         if (!is.element(this.elements.controls)) {

--- a/src/sass/components/controls.scss
+++ b/src/sass/components/controls.scss
@@ -112,4 +112,7 @@
 
 .plyr__controls:empty {
     display: none;
+    ~ .plyr__captions {
+        transform: translateY(0px);
+    }
 }

--- a/src/sass/components/controls.scss
+++ b/src/sass/components/controls.scss
@@ -109,3 +109,7 @@
 .plyr--fullscreen-enabled [data-plyr='fullscreen'] {
     display: inline-block;
 }
+
+.plyr__controls:empty {
+    display: none;
+}

--- a/src/sass/components/controls.scss
+++ b/src/sass/components/controls.scss
@@ -112,7 +112,8 @@
 
 .plyr__controls:empty {
     display: none;
+    
     ~ .plyr__captions {
-        transform: translateY(0px);
+        transform: translateY(0);
     }
 }


### PR DESCRIPTION
### Link to related issue (if applicable)
None.

### Summary of proposed changes
If the plyr__controls is empty it is still showing the fading transition causing captions to be pushed up when hovering over where the controls would be. This change hides the plyr__controls div when it is empty.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
