### PR TITLE
Size plyr container with width="size" value of Video element

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -50,10 +50,17 @@ function toggleFallback(toggle = false) {
 }
 
 class Fullscreen {
+    var fWidth = '';
     constructor(player) {
         // Keep reference to parent
         this.player = player;
-
+        // Set width or Styling from video element attribute, in this case width
+			
+        if (_this.player.media.hasAttribute('width')) {
+            fWidth = _this.player.media.getAttribute('width');
+            _this.player.elements.container.setAttribute('style', 'max-width: ' + fWidth + '');
+        }
+        
         // Get prefix
         this.prefix = Fullscreen.prefix;
         this.property = Fullscreen.property;
@@ -68,6 +75,25 @@ class Fullscreen {
             document,
             this.prefix === 'ms' ? 'MSFullscreenChange' : `${this.prefix}fullscreenchange`,
             () => {
+                
+          // FIX to retain sizes when escaping fullscreen 
+			if (document.addEventListener) {
+            document.addEventListener('webkitfullscreenchange', exitHandler, false);
+            document.addEventListener('mozfullscreenchange', exitHandler, false);
+            document.addEventListener('fullscreenchange', exitHandler, false);
+            document.addEventListener('MSFullscreenChange', exitHandler, false);
+			}   
+			function exitHandler() {
+			  if (!document.webkitIsFullScreen && !document.mozFullScreen && !document.msFullscreenElement) {
+				  
+			   if (_this.player.media.hasAttribute('width')) {
+					fWidth = _this.player.media.getAttribute('width');			
+					_this.player.elements.container.setAttribute('style', 'max-width: ' + fWidth + '');
+				}
+				//window.location.reload(false);
+			  }
+			}
+                
                 // TODO: Filter for target??
                 onChange.call(this);
             },
@@ -84,6 +110,11 @@ class Fullscreen {
         });
 
         // Update the UI
+        
+        // Remove styling for fullscreen
+       if(this.player.fullscreen.active) {						
+          this.player.elements.container.removeAttribute('style');
+        }
         this.update();
     }
 
@@ -174,7 +205,10 @@ class Fullscreen {
         if (!this.enabled) {
             return;
         }
-
+        
+        // Remove style when Enter fullscreen
+		this.player.elements.container.removeAttribute('style');
+        
         // iOS native fullscreen doesn't need the request step
         if (browser.isIos && this.player.config.fullscreen.iosNative) {
             if (this.player.playing) {


### PR DESCRIPTION
Makes plyr containers same width as originating <video> element "width" attribute works for any number of videos on same page fullscreen escape click and esc button also works, I needed this to have plyr working as <video> element in Tinymce and be treated as such and be able to set  size of video in <video> element attribute something which would be logical for starters :)..

### Link to related issue (if applicable)

### Summary of proposed changes

### Checklist
- [ ] Use `develop` as the base branch
- [ ] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
