### PR TITLE
Controls input fixes

### DIFF
--- a/controls.md
+++ b/controls.md
@@ -3,7 +3,9 @@
 This is the markup that is rendered for the Plyr controls. You can use the default controls or provide a customized version of markup based on your needs. You can pass the following to the `controls` option:
 
 -   `Array` of options (this builds the default controls based on your choices)
+-   `Element` with the controls
 -   `String` containing the desired HTML
+-   `false` (or empty string or array) to disable all controls
 -   `Function` that will be executed and should return one of the above
 
 ## Using default controls

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1117,11 +1117,6 @@ const controls = {
     // Build the default HTML
     // TODO: Set order based on order in the config.controls array?
     create(data) {
-        // Do nothing if we want no controls
-        if (is.empty(this.config.controls)) {
-            return null;
-        }
-
         // Create the container
         const container = createElement('div', getAttributesFromSelector(this.config.selectors.controls.wrapper));
 
@@ -1401,13 +1396,19 @@ const controls = {
         };
         let update = true;
 
-        if (is.string(this.config.controls) || is.element(this.config.controls)) {
-            // String or HTMLElement passed as the option
+        // If function, run it and use output
+        if (is.function(this.config.controls)) {
+            this.config.controls = this.config.controls.call(this.props);
+        }
+
+        // Convert falsy controls to empty array (primarily for empty strings)
+        if (!this.config.controls) {
+            this.config.controls = [];
+        }
+
+        if (is.element(this.config.controls) || is.string(this.config.controls)) {
+            // HTMLElement or Non-empty string passed as the option
             container = this.config.controls;
-        } else if (is.function(this.config.controls)) {
-            // A custom function to build controls
-            // The function can return a HTMLElement or String
-            container = this.config.controls.call(this, props);
         } else {
             // Create controls
             container = controls.create.call(this, {


### PR DESCRIPTION
Fixes some issues with the `controls` option.
* It should support a function that returns an array ([this is documented](https://github.com/sampotts/plyr/blob/master/controls.md#controls)).
* The documentation should include the `Element` type.
* `null` shouldn't be printed when the controls are `[]` (regression in my e5e169a, see [test pen](https://codepen.io/fullkornslimpa/pen/NBXOXG)).
* There should always be an element for the lower controls, even if there aren't any lower controls (fixes the positioning for third example in the #1137 codepen). Note that there are other ways to fix this issue, for example changing the css. The reason I went with this is that it also fixed the previous issue ^ and I think `controls.create()` shouldn't output null.

In addition
* If `controls` is falsy, the menu will now be empty (`undefined` shouldn't be falsy due to how the options are extended unless `Plyr.defaults.controls` is also unset). 


### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
- [x] Test on Chrome only since the changes are not browser-specific or prone to browser issues.
