### PR TITLE
Improve captions positioning consistency

### DIFF
--- a/src/sass/components/captions.scss
+++ b/src/sass/components/captions.scss
@@ -17,7 +17,6 @@
     padding: $plyr-control-spacing;
     position: absolute;
     text-align: center;
-    transform: translateY(-($plyr-control-spacing * 4));
     transition: transform 0.4s ease-in-out;
     width: 100%;
 
@@ -53,6 +52,8 @@
     display: block;
 }
 
-.plyr--hide-controls .plyr__captions {
-    transform: translateY(-($plyr-control-spacing * 1.5));
+// If the lower controls are shown and not empty
+.plyr:not(.plyr--hide-controls) .plyr__controls:not(:empty) ~ .plyr__captions {
+    transform: translateY(-($plyr-control-spacing * 4));
 }
+

--- a/src/sass/components/controls.scss
+++ b/src/sass/components/controls.scss
@@ -2,6 +2,11 @@
 // Controls
 // --------------------------------------------------------------
 
+// Hide empty controls
+.plyr__controls:empty {
+    display: none;
+}
+
 // Hide native controls
 .plyr--full-ui ::-webkit-media-controls {
     display: none;
@@ -108,12 +113,4 @@
 .plyr--airplay-supported [data-plyr='airplay'],
 .plyr--fullscreen-enabled [data-plyr='fullscreen'] {
     display: inline-block;
-}
-
-.plyr__controls:empty {
-    display: none;
-    
-    ~ .plyr__captions {
-        transform: translateY(0);
-    }
 }


### PR DESCRIPTION
### Link to related issue (if applicable)
#1137

### Summary of proposed changes
Makes sure the captions are only repositioned when there is a non-empty, non-hidden lower menu (rather than making css exceptions later).

Also moved up the rule to hide the empty controls and added a comment, as I think this is an important rule to the semantics.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on Crome only and checked caniuse that these changes should be safe for IE9+
- [ ] Actually tested the above
