### PR TITLE
Remove 'video is playing' requirement for iosNative fullscreen

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -177,9 +177,7 @@ class Fullscreen {
 
         // iOS native fullscreen doesn't need the request step
         if (browser.isIos && this.player.config.fullscreen.iosNative) {
-            if (this.player.playing) {
-                this.target.webkitEnterFullscreen();
-            }
+            this.target.webkitEnterFullscreen();
         } else if (!Fullscreen.native) {
             toggleFallback.call(this, true);
         } else if (!this.prefix) {


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1133

### Summary of proposed changes
Allow iosNative to go fullscreen when player is stopped.

Note: Neither @friday or I know why there ever was a restriction on going fullscreen while player stopped. Can only assume either an accident, or that it didn't work on a previous version of IOS.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [~] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
  - Have tested on MacOS Safari, Chrome, Firefox; IOS(latest) Safari, Chrome. Don't have older IOS to test, sorry, but figure that if there was an issue there it would've just.. not gone fullscreen (maybe popped an error into the console)

Have also tested while video has not yet been played after page load, per @friday's recommendation, and it's fine.