### PR TITLE
Prevent double firing of media play()

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -372,7 +372,7 @@ class Listeners {
             }
 
             // On click play, pause ore restart
-            on.call(player, elements.container, 'click touchstart', event => {
+            on.call(player, elements.container, 'click', event => {
                 const targets = [elements.container, wrapper];
 
                 // Ignore if click if not container or in video wrapper


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1162

### Summary of proposed changes
Stop firing video play/pause on `touchstart`, as it was causing duplicate hits alongside the `click` event - it's not an either/or.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [~] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
  - Android Chrome, IOS, MacOs Chrome...
