### PR TITLE
Add quality option to vimeo parameters

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -91,6 +91,7 @@ const vimeo = {
             loop: player.config.loop.active,
             autoplay: player.autoplay,
             // muted: player.muted,
+            quality: player.config.quality,
             byline: false,
             portrait: false,
             title: false,


### PR DESCRIPTION
Vimeo supports default quality settings for embeds, see https://help.vimeo.com/hc/en-us/articles/224983008-Setting-default-quality-for-embedded-videos
As such, quality settings of 4K, 2K, 1080p, 720p, 540p, and 360p are valid.

### Link to related issue (if applicable)

### Summary of proposed changes

### Checklist
- [ ] Use `develop` as the base branch
- [ ] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
