### PR TITLE
Fix keyboard focus

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -266,6 +266,7 @@ class Listeners {
         // Keyboard shortcuts
         if (!player.config.keyboard.global && player.config.keyboard.focused) {
             on.call(player, elements.container, 'keydown keyup', this.handleKey, false);
+            on.call(player, elements.container, 'click', player.setContainerFocus, false);
         }
 
         // Toggle controls on mouse events and entering fullscreen

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -265,6 +265,9 @@ class Plyr {
             wrap(this.media, this.elements.container);
         }
 
+        // Make container focusable
+        this.elements.container.tabIndex = 0;
+
         // Add style hook
         ui.addStyleHook.call(this);
 
@@ -342,6 +345,9 @@ class Plyr {
         if (!is.function(this.media.play)) {
             return null;
         }
+
+        // Focus on video
+        this.setContainerFocus();
 
         // Return the promise (for HTML5)
         return this.media.play();
@@ -910,6 +916,15 @@ class Plyr {
         // Show dialog if supported
         if (support.airplay) {
             this.media.webkitShowPlaybackTargetPicker();
+        }
+    }
+
+    /**
+     * Focus on the container
+     */
+    setContainerFocus() {
+        if (this.elements && this.elements.container) {
+            this.elements.container.focus();
         }
     }
 


### PR DESCRIPTION
### Summary of proposed changes
Focused keyboard input did not register when clicking on the video. This makes the container focusable so that it will focus the keyboard input wherever you click on the video.