### PR TITLE
Prevent immediate hiding of controls on mobile

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -620,6 +620,9 @@ class Listeners {
                 return;
             }
 
+            // Record seek time so we can prevent hiding controls for a few seconds after seek
+            player.lastSeekTime = Date.now();
+
             // Was playing before?
             const play = seek.hasAttribute(attribute);
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -302,6 +302,9 @@ class Plyr {
         if (this.config.autoplay) {
             this.play();
         }
+
+        // Seek time will be recorded (in listeners.js) so we can prevent hiding controls for a few seconds after seek
+        this.lastSeekTime = 0;
     }
 
     // ---------------------------------------

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -247,8 +247,11 @@ const ui = {
         const { controls } = this.elements;
 
         if (controls && this.config.hideControls) {
-            // Show controls if force, loading, paused, or button interaction, otherwise hide
-            this.toggleControls(Boolean(force || this.loading || this.paused || controls.pressed || controls.hover));
+            // Don't hide controls if a touch-device user recently seeked. (Must be limited to touch devices, or it occasionally prevents desktop controls from hiding.)
+            const recentTouchSeek = (this.touch && this.lastSeekTime + 2000 > Date.now());
+
+            // Show controls if force, loading, paused, button interaction, or recent seek, otherwise hide
+            this.toggleControls(Boolean(force || this.loading || this.paused || controls.pressed || controls.hover || recentTouchSeek));
         }
     },
 };


### PR DESCRIPTION
### Link to related issue (if applicable)
NA. Chatted about it on slack

### Summary of proposed changes
Current behaviour: When a touch device user taps/slides the seek bar, the controls disappear immediately. This doesn't happen on non-touch, thanks to controls.hover.

Issue: While this is ideal on play event, it's not ideal for seek:
1. UX: While seeking, a user doesn't know exactly where they want to land, and often has to seek multiple times. It's a bit jarring to have the seek bar disappear immediately.
2. If the player needs to load after seeking, the current functionality causes the controls to disappear, , reappear while loading, then disappear again immediately after. When all this happens in the space of a second, it just looks like a flicker/bug.

Solution: Prevent hiding of controls within 2 seconds of seeking.
I've implemented this is a timer. This doesn't feel ideal, but it was much messier to do it otherwise. This is because checkPlaying() and checkLoading() are fired 4-6 times after seeking, and we don't want to just prevent toggleControls() from these functions entirely on mobile, as that would prevent hiding controls on play(). The timer of 2 seconds was chosen because it's right in-between the immediate show attempts, and the existing 4-second hide timer.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)