### PR TITLE
Update default sprite URL for 3.4.5

### DIFF
--- a/src/js/config/defaults.js
+++ b/src/js/config/defaults.js
@@ -60,7 +60,7 @@ const defaults = {
     // Sprite (for icons)
     loadSprite: true,
     iconPrefix: 'plyr',
-    iconUrl: 'https://cdn.plyr.io/3.3.12/plyr.svg',
+    iconUrl: 'https://cdn.plyr.io/3.4.5/plyr.svg',
 
     // Blank video (used to prevent errors on source change)
     blankVideo: 'https://cdn.plyr.io/static/blank.mp4',


### PR DESCRIPTION
### Link to related issue (if applicable)
None.

### Summary of proposed changes
The new `download` icon is missing since the default sprite URL is set to `https://cdn.plyr.io/3.3.12/plyr.svg`.  
This PR changes the URL to use the `3.4.5` version of the SVG.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
