### PR TITLE
Calling customized controls function with proper arguments

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1587,7 +1587,7 @@ const controls = {
 
         // If function, run it and use output
         if (is.function(this.config.controls)) {
-            this.config.controls = this.config.controls.call(this.props);
+            this.config.controls = this.config.controls.call(this, props);
         }
 
         // Convert falsy controls to empty array (primarily for empty strings)


### PR DESCRIPTION
### Summary of proposed changes

When I pass a function to customized controls, its not get correct `this` context because the function `call` with incorrect `this` context.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
