### PR TITLE
Ensure custom handlers are called on container clicks that trigger togglePlay or restart

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -387,7 +387,7 @@ class Listeners {
 
                 if (player.ended) {
                     this.proxy(event, player.restart, 'restart');
-                    this.proxy(event, player.togglePlay, 'play');
+                    this.proxy(event, player.play, 'play');
                 } else {
                     this.proxy(event, player.togglePlay, 'play');
                 }

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -386,10 +386,10 @@ class Listeners {
                 }
 
                 if (player.ended) {
-                    player.restart();
-                    player.play();
+                    this.proxy(event, player.restart, 'restart');
+                    this.proxy(event, player.togglePlay, 'play');
                 } else {
-                    player.togglePlay();
+                    this.proxy(event, player.togglePlay, 'play');
                 }
             });
         }


### PR DESCRIPTION
### Link to related issue (if applicable)
This PR fixes issue #858 --- Custom listeners were not being called when the plyr container was clicked (triggering play/pause).

### Summary of proposed changes
  - Replaced calls to `player.restart()` and `player.togglePlay()` with `proxy(...)`

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)

I don't know how to test on _all_ the supported browsers. So far, I have tested it on Chrome and Firefox and it works.