### PR TITLE
fix: Use Math.trunc instead of parseInt

### DIFF
--- a/src/js/utils/time.js
+++ b/src/js/utils/time.js
@@ -5,9 +5,9 @@
 import is from './is';
 
 // Time helpers
-export const getHours = value => parseInt((value / 60 / 60) % 60, 10);
-export const getMinutes = value => parseInt((value / 60) % 60, 10);
-export const getSeconds = value => parseInt(value % 60, 10);
+export const getHours = value => Math.trunc((value / 60 / 60) % 60, 10);
+export const getMinutes = value => Math.trunc((value / 60) % 60, 10);
+export const getSeconds = value => Math.trunc(value % 60, 10);
 
 // Format time to UI friendly string
 export function formatTime(time = 0, displayHours = false, inverted = false) {


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
`parseInt` coerces its input to a string before attempting to parse it. This means that, for very small fractions that stringify as something like "5e-7", these `parseInt` calls will not actually truncate the values to 0 as presumably desired, but will give the leading digit.

This leads to our seeing the formatted current time shoot up to a large value immediately after the video loops, as the next indicated time becomes a small enough number that, after being converted from seconds to hours, is small enough to trigger that issue with scientific notation above.

This replaces the usages of `parseInt` for time formatting with `Math.trunc`, which has the right behavior. There's another use for parsing the progress in the Vimeo plugin where I'm not too sure what's going on. It looks like that usage can also be safely replaced with either `Math.trunc` or `Math.floor`, but I'm not sure if I'm missing something there; it's not clear to me why that progress needs to be rounded or parsed in the first place.

Also, before doing browser testing, I wanted to confirm that it's okay to use an ES6 feature that isn't supported in the full browser matrix without polyfills.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)