### PR TITLE
fix: Properly clear all timeouts on destroy

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1088,11 +1088,13 @@ class Plyr {
         // Stop playback
         this.stop();
 
+        // Clear timeouts
+        clearTimeout(this.timers.loading);
+        clearTimeout(this.timers.controls);
+        clearTimeout(this.timers.resized);
+
         // Provider specific stuff
         if (this.isHTML5) {
-            // Clear timeout
-            clearTimeout(this.timers.loading);
-
             // Restore native video controls
             ui.toggleNativeControls.call(this, true);
 


### PR DESCRIPTION
### Link to related issue (if applicable)
Fixes https://github.com/sampotts/plyr/issues/853

### Summary of proposed changes
In `destroy`, clear some timeouts that previously weren't being cleared.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
