### PR TITLE
Make menu work in WebComponent

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1191,7 +1191,7 @@ const controls = {
 
     // Show a panel in the menu
     showMenuPanel(type = '', tabFocus = false) {
-        const target = document.getElementById(`plyr-settings-${this.id}-${type}`);
+        const target = this.elements.container.querySelector(`#plyr-settings-${this.id}-${type}`);
 
         // Nothing to show, bail
         if (!is.element(target)) {

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1138,7 +1138,9 @@ const controls = {
         } else if (is.keyboardEvent(input) && input.which === 27) {
             show = false;
         } else if (is.event(input)) {
-            const isMenuItem = popup.contains(input.target);
+            // If Plyr is in a shadowDOM, the event target is set to the component, instead of the
+            // element in the shadowDOM. The path, however, is complete.
+            const isMenuItem = popup.contains(input.path[0]);
 
             // If the click was inside the menu or if the click
             // wasn't the button or menu item and we're trying to


### PR DESCRIPTION
### Link to related issue (if applicable)
#1415 

### Summary of proposed changes
When showing the menu, use a `queryselector` on the container element instead of `document.getElementById` and use the `path` of MouseEvents instead of the target to overcome the limitations of the shadowDOM encapsulation.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
