### PR TITLE
Fixed problem with displaying subtitles has been solved

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -232,6 +232,9 @@ const captions = {
         if (this.captions.currentTrack !== index) {
             this.captions.currentTrack = index;
             const track = tracks[index];
+
+            track.mode = 'showing';
+
             const { language } = track || {};
 
             // Store reference to node for invalidation on remove


### PR DESCRIPTION
### Link to related issue (if applicable)
Link: https://codepen.io/anon/pen/dLmdEO
### Summary of proposed changes
When using subtitles in m3u8, there was no reflection, nothing happened when the button was pressed
### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
