### PR TITLE
Prevent default on settings control click

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -603,12 +603,19 @@ class Listeners {
         this.bind(elements.buttons.airplay, 'click', player.airplay, 'airplay');
 
         // Settings menu - click toggle
-        this.bind(elements.buttons.settings, 'click', event => {
-            // Prevent the document click listener closing the menu
-            event.stopPropagation();
+        this.bind(
+            elements.buttons.settings,
+            'click',
+            event => {
+                // Prevent the document click listener closing the menu
+                event.stopPropagation();
+                event.preventDefault();
 
-            controls.toggleMenu.call(player, event);
-        });
+                controls.toggleMenu.call(player, event);
+            },
+            null,
+            false
+        ); // Can't be passive as we're preventing default
 
         // Settings menu - keyboard toggle
         // We have to bind to keyup otherwise Firefox triggers a click when a keydown event handler shifts focus


### PR DESCRIPTION
### Link to related issue (if applicable)
n/a

### Summary of proposed changes
I've run into an issue on our platform, we embed a video player within a card. The entire card is clickable (wrapped in an `a` element).

We've written a basic event suppressor that wraps the video, and some other links that we have within that card – it's not ideal, but it works with exception to the Settings control.

Our suppressor works by listening for events that bubble up to the container, and stopping the propagation any further, and preventing the default.

Because the settings event listener in plyr currently only stops propagation I am unable to prevent the default, and therefore whenever the settings control is clicked, the user is taken to another page.

Hope this is all good, figured it's a minor enough change that it doesn't need a changelog note, or documentation change.

I've tested on the browsers I have access to - I don't have access to Opera, or IEs.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
