### PR TITLE
Detach event listeners on destroy

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -402,7 +402,8 @@ const controls = {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1220143
     bindMenuItemShortcuts(menuItem, type) {
         // Navigate through menus via arrow keys and space
-        on(
+        on.call(
+            this,
             menuItem,
             'keydown keyup',
             event => {
@@ -452,7 +453,7 @@ const controls = {
 
         // Enter will fire a `click` event but we still need to manage focus
         // So we bind to keyup which fires after and set focus here
-        on(menuItem, 'keyup', event => {
+        on.call(this, menuItem, 'keyup', event => {
             if (event.which !== 13) {
                 return;
             }
@@ -1463,7 +1464,7 @@ const controls = {
                     bindMenuItemShortcuts.call(this, menuItem, type);
 
                     // Show menu on click
-                    on(menuItem, 'click', () => {
+                    on.call(this, menuItem, 'click', () => {
                         showMenuPanel.call(this, type, false);
                     });
 
@@ -1515,7 +1516,8 @@ const controls = {
                     );
 
                     // Go back via keyboard
-                    on(
+                    on.call(
+                        this,
                         pane,
                         'keydown',
                         event => {
@@ -1535,7 +1537,7 @@ const controls = {
                     );
 
                     // Go back via button click
-                    on(backButton, 'click', () => {
+                    on.call(this, backButton, 'click', () => {
                         showMenuPanel.call(this, 'home', false);
                     });
 


### PR DESCRIPTION
If `on` receives `this`, it attaches `eventListeners` array to `this` and stores `{ element, type, callback }` hash in there. Later, during the destruction process, all the entries from this array will be processed by `unbindListeners` helper to detach all the event listeners.

### Link to related issue (if applicable)

None

### Summary of proposed changes

Detach event listeners on destroy

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)

### Sidestory

In one of the projects in which I participate, we ensure that all of the event listeners detach on destroy. To do this, we use a little homemade karma plugin, that started to complain about the abandoned event listeners after the upgrade from `plyr@3.3.21` to `plyr@3.5.6`: 

```
Failed: Some module attached element-listeners on init but did not detach them on destroy:
  [Function: function (event) { // We only care about space and ⬆️ ⬇️️ ➡️ if (![32, 38, 39, 40].includes(event.which)) { return; } //...] as "keydown" event listener has been attached to <button class="plyr__control plyr__control--forward">
  [Function: function (event) { // We only care about space and ⬆️ ⬇️️ ➡️ if (![32, 38, 39, 40].includes(event.which)) { return; } //...] as "keyup" event listener has been attached to <button class="plyr__control plyr__control--forward">
  [Function: function (event) { if (event.which !== 13) { return; } controls.focusFirstMenuItem.call(_this2, null, true); }] as "keyup" event listener has been attached to <button class="plyr__control plyr__control--forward">
  [Function: function () { showMenuPanel.call(_this10, type, false); }] as "click" event listener has been attached to <button class="plyr__control plyr__control--forward">
  [Function: function (event) { // We only care about <- if (event.which !== 37) { return; } // Prevent seek event.preventDefault(...] as "keydown" event listener has been attached to <div id="plyr-settings-1116-captions">
  [Function: function () { showMenuPanel.call(_this10, 'home', false); }] as "click" event listener has been attached to <button class="plyr__control plyr__control--back">
```
