### PR TITLE
♿️(controls) change play button aria-label value when its state change

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -214,6 +214,7 @@ const ui = {
         // Set state
         Array.from(this.elements.buttons.play || []).forEach(target => {
             Object.assign(target, { pressed: this.playing });
+            target.setAttribute('aria-label', i18n.get(this.playing ? 'pause' : 'play', this.config));
         });
 
         // Only update controls on non timeupdate events


### PR DESCRIPTION
### Summary of proposed changes

The aria-label attribute set on all play buttons does not change
according to the player state. When the video is playing, the aria-label
should change to pause otherwise screen reader will not detect that this
button now can be used to pause the video.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
