### PR TITLE
Fix ads configuration

### DIFF
--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -136,7 +136,7 @@ class Ads {
             cb: Date.now(),
             AV_WIDTH: 640,
             AV_HEIGHT: 480,
-            AV_CDIM2: this.publisherId,
+            AV_CDIM2: config.publisherId,
         };
 
         const base = 'https://go.aniview.com/api/adserver6/vast/';


### PR DESCRIPTION
The defined publisherId is never being transferred to aniview.com due to a typo (there's no `publisherId` in the current scope). Instead, `AV_CDIM2` is always `null` respectively `undefined`.