### PR TITLE
Prevents IE11 with resetOnEnd option set to true to play video again

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -390,6 +390,8 @@ class Listeners {
             if (player.isHTML5 && player.isVideo && player.config.resetOnEnd) {
                 // Restart
                 player.restart();
+                // call pause otherwise IE11 will start playing the video again
+                player.pause();
             }
         });
 


### PR DESCRIPTION
When using resetOnEnd after the video finish it start playing again. To prevent this weird behavior and make all browsers behave the same I've added a ```player.pause();``` call right after the ```player.restart();``` without any side effects.

How to reproduce:
https://codesandbox.io/s/static-z964e

Fixed version:
https://fetbx.csb.app/