### PR TITLE
#615: updates to vimeo and youtube buffering state

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -335,6 +335,14 @@ const vimeo = {
             }
         });
 
+        player.embed.on('bufferstart', () => {
+            triggerEvent.call(player, player.media, 'waiting');
+        });
+
+        player.embed.on('bufferend', () => {
+            triggerEvent.call(player, player.media, 'playing');
+        });
+
         player.embed.on('play', () => {
             assurePlaybackState.call(player, true);
             triggerEvent.call(player, player.media, 'playing');

--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -416,6 +416,12 @@ const youtube = {
 
                             break;
 
+                        case 3:
+                            // Trigger waiting event to add loading classes to container as the video buffers.
+                            triggerEvent.call(player, player.media, 'waiting');
+
+                            break;
+
                         default:
                             break;
                     }


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/615

### Summary of proposed changes
Updates to Vimeo and Youtube plugins to trigger loading events as videos are buffering.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
