### PR TITLE
fix: Fix handling listener return value

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -513,7 +513,7 @@ class Listeners {
         }
 
         // Only call default handler if not prevented in custom handler
-        if (returned && is.function(defaultHandler)) {
+        if (returned !== false && is.function(defaultHandler)) {
             defaultHandler.call(player, event);
         }
     }


### PR DESCRIPTION
Fixes #1491

### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1492

### Summary of proposed changes
Only ignore default listener if custom listener explicitly returns `false`.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)

I'm not sure if any of the built-in plugins depend on the old behavior. I clicked around in the demo for a bit around things like full-screen, and I didn't notice any odd behavior there.