### PR TITLE
Preserve viewBox attribute in SVG sprite symbols

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -222,7 +222,11 @@ Object.entries(build.sprite).forEach(([filename, entry]) => {
         gulp
             .src(src)
             .pipe(plumber())
-            .pipe(imagemin())
+            .pipe(imagemin([
+                imagemin.svgo({
+                  plugins: [{ removeViewBox: false }]
+                })
+              ]))
             .pipe(svgstore())
             .pipe(rename({ basename: path.parse(filename).name }))
             .pipe(size(sizeOptions))


### PR DESCRIPTION
When generating the SVG sprite (using imagemin and svgstore) the imagemin
step needs to NOT cleanup/remove the viewBox attributes from the
individual svg files.

fixes #1306