### PR TITLE
IOS - Fix being unable to unmute auto-played videos

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1380,7 +1380,7 @@ const controls = {
                 }
 
                 // Volume range control
-                if (control === 'volume') {
+                if (control === 'volume' && !browser.isIos) {
                     // Set the attributes
                     const attributes = {
                         max: 1,

--- a/src/sass/components/volume.scss
+++ b/src/sass/components/volume.scss
@@ -23,13 +23,6 @@
     }
 }
 
-// Hide sound controls on iOS
-// It's not supported to change volume using JavaScript:
-// https://developer.apple.com/library/safari/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html
-.plyr--is-ios .plyr__volume {
-    display: none !important;
-}
-
 // Vimeo has no toggle mute method so hide mute button
 // https://github.com/vimeo/player.js/issues/236#issuecomment-384663183
 .plyr--is-ios.plyr--vimeo [data-plyr='mute'] {


### PR DESCRIPTION
### Link to related issue
#1614
#1457
#1310

### Summary of proposed changes
We now always show the Volume button so that autoplayed videos on IOS can be unmuted. The input slider won't show on IOS since it does nothing (as the volume level is controlled at OS level).

<img src="https://user-images.githubusercontent.com/12093664/70075915-f4009280-15ba-11ea-8c77-f270032e1054.png" width="350" />

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
