### PR TITLE
Use the configured speed options

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1056,6 +1056,8 @@ const controls = {
         // Set the speed options
         if (is.array(options)) {
             this.options.speed = options;
+        } else if (is.array(this.config.speed.options)) {
+            this.options.speed = this.config.speed.options;
         } else if (this.isHTML5 || this.isVimeo) {
             this.options.speed = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
         }


### PR DESCRIPTION
This fixes #1342 by actually using the configured speed options for html5 instead of falling back to the default array.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on latest Firefox & Chrome
