### PR TITLE
Improve/fix quality change state restoring

### DIFF
--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -89,9 +89,6 @@ const html5 = {
                     if (preload !== 'none' || readyState) {
                         // Restore time
                         player.once('loadedmetadata', () => {
-                            if (player.currentTime === 0) {
-                                return;
-                            }
 
                             player.currentTime = currentTime;
 

--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -80,7 +80,7 @@ const html5 = {
                     }
 
                     // Get current state
-                    const { currentTime, paused, preload, readyState } = player.media;
+                    const { currentTime, paused, preload, readyState, playbackRate } = player.media;
 
                     // Set new source
                     player.media.src = source.getAttribute('src');
@@ -90,6 +90,7 @@ const html5 = {
                         // Restore time
                         player.once('loadedmetadata', () => {
 
+                            player.speed = playbackRate;
                             player.currentTime = currentTime;
 
                             // Resume playing


### PR DESCRIPTION
This fixes a regression which was added by https://github.com/sampotts/plyr/commit/71d6f59d5619845aafe5c4414831e56d310700ff which prevents the player from restoring the play state after changing quality.

Changing quality now also restores the playbackRate and thus it fixes #1436

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on latest Firefox & Chrome
