### PR TITLE
Trap keyboard focus only when fullscreen

### DIFF
--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -257,10 +257,11 @@ export function trapFocus(element = null, toggle = false) {
     const focusable = getElements.call(this, 'button:not(:disabled), input:not(:disabled), [tabindex]');
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
+    const player = this;
 
     const trap = event => {
         // Bail if not tab key or not fullscreen
-        if (event.key !== 'Tab' || event.keyCode !== 9) {
+        if (event.key !== 'Tab' || event.keyCode !== 9 || !player.fullscreen.active) {
             return;
         }
 


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1665

### Summary of proposed changes
Include the check 
`!player.fullscreen.active` within the trapFocus function
before trapping keyboard focus.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Tested on latest Chrome, Firefox, Edge
