### PR TITLE
Add download attribute to download button

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1580,6 +1580,7 @@ const controls = {
                     element: 'a',
                     href: this.download,
                     target: '_blank',
+                    download: '',
                 });
 
                 const { download } = this.config.urls;


### PR DESCRIPTION
### Link to related issue (if applicable)
Partially fixes #1478. The fix only works for same origin content and browsers that support HTML5.

### Summary of proposed changes
When clicking the download-button, a new browser window is opened an the content is displayed, instead of showing a save as dialog. To get around this, we can add the `download` attribute to the `<a>` element (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support) --> Only tested with Firefox and Chrome.
