### PR TITLE
Fix preview thumbnail scrubbing not working on mobile touch devices

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -725,7 +725,7 @@ class Listeners {
         });
 
         // Hide thumbnail preview - on mouse click, mouse leave, and video play/seek. All four are required, e.g., for buffering
-        this.bind(elements.progress, 'mouseleave click', () => {
+        this.bind(elements.progress, 'mouseleave touchend click', () => {
             const { previewThumbnails } = player;
 
             if (previewThumbnails && previewThumbnails.loaded) {

--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -239,8 +239,8 @@ class PreviewThumbnails {
     }
 
     startScrubbing(event) {
-        // Only act on left mouse button (0), or touch device (event.button is false)
-        if (event.button === false || event.button === 0) {
+        // Only act on left mouse button (0), or touch device (event.button does not exist or is false)
+        if (is.nullOrUndefined(event.button) || event.button === false || event.button === 0) {
             this.mouseDown = true;
 
             // Wait until media has a duration


### PR DESCRIPTION
Currently on Chrome Android the thumbnails preview pops up but is very small and does not update correctly.  
The code suggests that touch devices should only use the scrubbing feature (where the thumbnail is displayed on top of the video container).  

This pull request fixes the check at startScrubbing to properly handle TouchEvents which do not have a button property.

This also ensures that the preview popup is always hidden on touch end.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
