### PR TITLE
Added missing full screen options for type definition

### DIFF
--- a/src/js/plyr.d.ts
+++ b/src/js/plyr.d.ts
@@ -507,6 +507,7 @@ declare namespace Plyr {
         enabled?: boolean;
         fallback?: boolean;
         allowAudio?: boolean;
+        iosNative?: boolean;
     }
 
     interface CaptionOptions {


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes

Add `iosNative` to type script definition. So it won't throw error for defining for it.

### Checklist
- [X] Use `develop` as the base branch
- [X] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
