### PR TITLE
Fix issue when controls config is string or element

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -151,7 +151,8 @@ const captions = {
         toggleClass(this.elements.container, this.config.classNames.captions.enabled, !is.empty(tracks));
 
         // Update available languages in list
-        if ((this.config.controls || []).includes('settings') && this.config.settings.includes('captions')) {
+        if ((is.array(this.config.controls) && this.config.controls.includes('settings'))
+            && this.config.settings.includes('captions')) {
             controls.setCaptionsMenu.call(this);
         }
     },


### PR DESCRIPTION
### Summary of proposed changes
When pass element as controls config, `capticon.update()` will throw exception.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)