### PR TITLE
Fix vimeo playback rate

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -204,6 +204,9 @@ const vimeo = {
                 player.embed.setPlaybackRate(input).then(() => {
                     speed = input;
                     triggerEvent.call(player, player.media, 'ratechange');
+                }).catch(() => {
+                    // Cannot set Playback Rate, Video is probably not on Pro account
+                    player.options.speed = [1];
                 });
             },
         });


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1696

Since updating to 3.5.9, all Vimeo videos not hosted on a Pro account throw:

> Uncaught (in promise) Error: Setting the playback rate is not enabled for this video.

This is because there is an attempt to set the playback rate on load.

We can only set the playback rate on videos hosted on Pro accounts.
There is no feature detection / getAvailableRates method available so we can actually use this to detect if the rate can be changed and amend the list of available speeds.

### Summary of proposed changes

Catch the error and change the available speeds list to reflect that only "1" is available.


### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
