### PR TITLE
Completely hide SVG icons to screen readers

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -111,7 +111,7 @@ const controls = {
         setAttributes(
             icon,
             extend(attributes, {
-                role: 'presentation',
+                'aria-hidden': 'true',
                 focusable: 'false',
             }),
         );


### PR DESCRIPTION
### Summary of proposed changes
SVG icons should be ignored by screen readers since they have complimentary labels (aria-label or plyr__sr-only). The current « presentation » role simply makes the element behave like a « span » which is incorrect, aria-hidden prevents screen readers from taking care of these elements at all.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
