### PR TITLE
preview-thumbnails via src:callback()

### DIFF
--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -137,19 +137,31 @@ class PreviewThumbnails {
                 throw new Error('Missing previewThumbnails.src config attribute');
             }
 
-            // If string, convert into single-element list
-            const urls = is.string(src) ? [src] : src;
-            // Loop through each src URL. Download and process the VTT file, storing the resulting data in this.thumbnails
-            const promises = urls.map(u => this.getThumbnail(u));
-
-            Promise.all(promises).then(() => {
+            // Resolve promise
+            const exec_resolve = () => {
                 // Sort smallest to biggest (e.g., [120p, 480p, 1080p])
                 this.thumbnails.sort((x, y) => x.height - y.height);
 
                 this.player.debug.log('Preview thumbnails', this.thumbnails);
 
                 resolve();
-            });
+            };
+            // Via callback()
+            if( typeof(src) == 'function' ) {
+                // Ask
+                this.thumbnails = src();
+                // Resolve
+                exec_resolve();
+            }
+            // VTT urls
+            else {
+                // If string, convert into single-element list
+                const urls = is.string(src) ? [src] : src;
+                // Loop through each src URL. Download and process the VTT file, storing the resulting data in this.thumbnails
+                const promises = urls.map(u => this.getThumbnail(u));
+                // Resolve
+                Promise.all(promises).then(exec_resolve);
+            }
         });
     }
 

--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -138,7 +138,7 @@ class PreviewThumbnails {
             }
 
             // Resolve promise
-            const exec_resolve = () => {
+            const resolvePromise = () => {
                 // Sort smallest to biggest (e.g., [120p, 480p, 1080p])
                 this.thumbnails.sort((x, y) => x.height - y.height);
 
@@ -147,11 +147,14 @@ class PreviewThumbnails {
                 resolve();
             };
             // Via callback()
-            if( typeof(src) == 'function' ) {
+            if (typeof(src) == 'function') {
                 // Ask
-                this.thumbnails = src();
-                // Resolve
-                exec_resolve();
+                let that = this;
+                src(function(thumbnails) {
+                    that.thumbnails = thumbnails;
+                    // Resolve
+                    resolvePromise();
+                });
             }
             // VTT urls
             else {
@@ -160,7 +163,7 @@ class PreviewThumbnails {
                 // Loop through each src URL. Download and process the VTT file, storing the resulting data in this.thumbnails
                 const promises = urls.map(u => this.getThumbnail(u));
                 // Resolve
-                Promise.all(promises).then(exec_resolve);
+                Promise.all(promises).then(resolvePromise);
             }
         });
     }

--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -138,7 +138,7 @@ class PreviewThumbnails {
             }
 
             // Resolve promise
-            const resolvePromise = () => {
+            const sortAndResolve = () => {
                 // Sort smallest to biggest (e.g., [120p, 480p, 1080p])
                 this.thumbnails.sort((x, y) => x.height - y.height);
 
@@ -147,13 +147,13 @@ class PreviewThumbnails {
                 resolve();
             };
             // Via callback()
-            if (typeof(src) == 'function') {
+            if (is.function(src)) {
                 // Ask
                 let that = this;
                 src(function(thumbnails) {
                     that.thumbnails = thumbnails;
                     // Resolve
-                    resolvePromise();
+                    sortAndResolve();
                 });
             }
             // VTT urls
@@ -163,7 +163,7 @@ class PreviewThumbnails {
                 // Loop through each src URL. Download and process the VTT file, storing the resulting data in this.thumbnails
                 const promises = urls.map(u => this.getThumbnail(u));
                 // Resolve
-                Promise.all(promises).then(resolvePromise);
+                Promise.all(promises).then(sortAndResolve);
             }
         });
     }


### PR DESCRIPTION
I have a request: We can't use the current VTT-`previewThumbnails` for some reasons.
Would you mind to extend the API with a callback (see the attached pull request)?

E.g.:
```` 
previewThumbnails: {
    enabled: true,
    src: function() {
        return [{
            frames: [{
                startTime: 0,
                endTime: 1000,
                text: "http://localhost/demo/240p-00001.jpg",
                x: 0,
                y: 0,
                w: 427,
                h: 240},
                //...
            ],
            width: 2135,
            height: 1200,
            urlPrefix: "",
        }];
    },
}
```` 