### PR TITLE
Ads plugin fixes to allow multiple VAST requests

### DIFF
--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -172,6 +172,17 @@ class Ads {
         // We assume the adContainer is the video container of the plyr element that will house the ads
         this.elements.displayContainer = new google.ima.AdDisplayContainer(this.elements.container, this.player.media);
 
+        // Create ads loader
+        this.loader = new google.ima.AdsLoader(this.elements.displayContainer);
+
+        // Listen and respond to ads loaded and error events
+        this.loader.addEventListener(
+            google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED,
+            event => this.onAdsManagerLoaded(event),
+            false,
+        );
+        this.loader.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, error => this.onAdError(error), false);
+
         // Request video ads to be pre-loaded
         this.requestAds();
     }
@@ -183,17 +194,6 @@ class Ads {
         const { container } = this.player.elements;
 
         try {
-            // Create ads loader
-            this.loader = new google.ima.AdsLoader(this.elements.displayContainer);
-
-            // Listen and respond to ads loaded and error events
-            this.loader.addEventListener(
-                google.ima.AdsManagerLoadedEvent.Type.ADS_MANAGER_LOADED,
-                event => this.onAdsManagerLoaded(event),
-                false,
-            );
-            this.loader.addEventListener(google.ima.AdErrorEvent.Type.AD_ERROR, error => this.onAdError(error), false);
-
             // Request video ads
             const request = new google.ima.AdsRequest();
             request.adTagUrl = this.tagUrl;
@@ -369,7 +369,14 @@ class Ads {
                 // TODO: So there is still this thing where a video should only be allowed to start
                 // playing when the IMA SDK is ready or has failed
 
-                this.loadAds();
+                if (player.ended){
+				    this.loadAds();
+			    }
+			    else
+			    {
+                    // The SDK won't allow new ads to be called without receiving a contentComplete()
+				    this.loader.contentComplete();
+			    }
 
                 break;
 
@@ -563,6 +570,8 @@ class Ads {
                     this.on('loaded', resolve);
                     this.player.debug.log(this.manager);
                 });
+                // Now that the manager has been destroyed set it to also be un-initialized
+                this.initialized = false;
 
                 // Now request some new advertisements
                 this.requestAds();


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes

The IMA Loader was being created multiple times. SDK recommends/requires it to only be created once per page load.

Code assumed that ALL_ADS_COMPLETE would be triggered after a video has ended assuming that all tagURLs would include a post-roll ad. Added check for player.ended.

Set ads.initialized = false when adManager is destroyed otherwise new managers aren't initialized. 

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
