### PR TITLE
Fix shadowroot

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -118,7 +118,7 @@ class Fullscreen {
 
         const element = !this.prefix ? document.fullscreenElement : document[`${this.prefix}${this.property}Element`];
 
-        return element === this.target;
+        return (element && element.shadowRoot) ? element === this.target.getRootNode().host : element === this.target;
     }
 
     // Get target element

--- a/src/js/utils/elements.js
+++ b/src/js/utils/elements.js
@@ -221,7 +221,7 @@ export function hasClass(element, className) {
 
 // Element matches selector
 export function matches(element, selector) {
-    const prototype = { Element };
+    const prototype = Element.prototype;
 
     function match() {
         return Array.from(document.querySelectorAll(selector)).includes(this);


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
1. Use correct prototype in the matches function to ensure the correct function is used. Fixes a bug where option highlighting was not removed if player is in Shadow DOM.
2. Compare document.fullscreenelement to rootnode host of target in fullscreen.js. Fixes a bug where fullscreen button would not toggle if player is in Shadow DOM.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
