### PR TITLE
Ignore internal play promises

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,30 +349,30 @@ player.play(); // Start playback
 player.fullscreen.enter(); // Enter fullscreen
 ```
 
-| Method                   | Parameters       | Description                                                                                                |
-| ------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------- |
-| `play()`&sup1;           | -                | Start playback.                                                                                            |
-| `pause()`                | -                | Pause playback.                                                                                            |
-| `togglePlay(toggle)`     | Boolean          | Toggle playback, if no parameters are passed, it will toggle based on current status.                      |
-| `stop()`                 | -                | Stop playback and reset to start.                                                                          |
-| `restart()`              | -                | Restart playback.                                                                                          |
-| `rewind(seekTime)`       | Number           | Rewind playback by the specified seek time. If no parameter is passed, the default seek time will be used. |
-| `forward(seekTime)`      | Number           | Fast forward by the specified seek time. If no parameter is passed, the default seek time will be used.    |
-| `increaseVolume(step)`   | Number           | Increase volume by the specified step. If no parameter is passed, the default step will be used.           |
-| `decreaseVolume(step)`   | Number           | Increase volume by the specified step. If no parameter is passed, the default step will be used.           |
-| `toggleCaptions(toggle)` | Boolean          | Toggle captions display. If no parameter is passed, it will toggle based on current status.                |
-| `fullscreen.enter()`     | -                | Enter fullscreen. If fullscreen is not supported, a fallback "full window/viewport" is used instead.       |
-| `fullscreen.exit()`      | -                | Exit fullscreen.                                                                                           |
-| `fullscreen.toggle()`    | -                | Toggle fullscreen.                                                                                         |
-| `airplay()`              | -                | Trigger the airplay dialog on supported devices.                                                           |
-| `toggleControls(toggle)` | Boolean          | Toggle the controls (video only). Takes optional truthy value to force it on/off.                          |
-| `on(event, function)`    | String, Function | Add an event listener for the specified event.                                                             |
-| `once(event, function)`  | String, Function | Add an event listener for the specified event once.                                                        |
-| `off(event, function)`   | String, Function | Remove an event listener for the specified event.                                                          |
-| `supports(type)`         | String           | Check support for a mime type.                                                                             |
-| `destroy()`              | -                | Destroy the instance and garbage collect any elements.                                                     |
+| Method                     | Parameters       | Description                                                                                                |
+| -------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| `play()`&sup1;             | -                | Start playback.                                                                                            |
+| `pause()`                  | -                | Pause playback.                                                                                            |
+| `togglePlay(toggle)`&sup1; | Boolean          | Toggle playback, if no parameters are passed, it will toggle based on current status.                      |
+| `stop()`                   | -                | Stop playback and reset to start.                                                                          |
+| `restart()`                | -                | Restart playback.                                                                                          |
+| `rewind(seekTime)`         | Number           | Rewind playback by the specified seek time. If no parameter is passed, the default seek time will be used. |
+| `forward(seekTime)`        | Number           | Fast forward by the specified seek time. If no parameter is passed, the default seek time will be used.    |
+| `increaseVolume(step)`     | Number           | Increase volume by the specified step. If no parameter is passed, the default step will be used.           |
+| `decreaseVolume(step)`     | Number           | Increase volume by the specified step. If no parameter is passed, the default step will be used.           |
+| `toggleCaptions(toggle)`   | Boolean          | Toggle captions display. If no parameter is passed, it will toggle based on current status.                |
+| `fullscreen.enter()`       | -                | Enter fullscreen. If fullscreen is not supported, a fallback "full window/viewport" is used instead.       |
+| `fullscreen.exit()`        | -                | Exit fullscreen.                                                                                           |
+| `fullscreen.toggle()`      | -                | Toggle fullscreen.                                                                                         |
+| `airplay()`                | -                | Trigger the airplay dialog on supported devices.                                                           |
+| `toggleControls(toggle)`   | Boolean          | Toggle the controls (video only). Takes optional truthy value to force it on/off.                          |
+| `on(event, function)`      | String, Function | Add an event listener for the specified event.                                                             |
+| `once(event, function)`    | String, Function | Add an event listener for the specified event once.                                                        |
+| `off(event, function)`     | String, Function | Remove an event listener for the specified event.                                                          |
+| `supports(type)`           | String           | Check support for a mime type.                                                                             |
+| `destroy()`                | -                | Destroy the instance and garbage collect any elements.                                                     |
 
-1.  For HTML5 players, `play()` will return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) in _some_ browsers - WebKit and Mozilla [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) at time of writing.
+1.  For HTML5 players, `play()` will return a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for most browsers - e.g. Chrome, Firefox, Opera, Safari and Edge [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play) at time of writing.
 
 ## Getters and Setters
 

--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -8,6 +8,7 @@ import browser from './utils/browser';
 import { getElements, hasClass, toggleClass } from './utils/elements';
 import { on, triggerEvent } from './utils/events';
 import is from './utils/is';
+import { silencePromise } from './utils/promise';
 
 class Fullscreen {
     constructor(player) {
@@ -268,7 +269,7 @@ class Fullscreen {
         // iOS native fullscreen
         if (browser.isIos && this.player.config.fullscreen.iosNative) {
             this.target.webkitExitFullscreen();
-            this.player.play();
+            silencePromise(this.player.play());
         } else if (!Fullscreen.native || this.forceFallback) {
             this.toggleFallback(false);
         } else if (!this.prefix) {

--- a/src/js/html5.js
+++ b/src/js/html5.js
@@ -6,6 +6,7 @@ import support from './support';
 import { removeElement } from './utils/elements';
 import { triggerEvent } from './utils/events';
 import is from './utils/is';
+import { silencePromise } from './utils/promise';
 import { setAspectRatio } from './utils/style';
 
 const html5 = {
@@ -101,7 +102,7 @@ const html5 = {
 
                             // Resume playing
                             if (!paused) {
-                                player.play();
+                                silencePromise(player.play());
                             }
                         });
 

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -9,6 +9,7 @@ import browser from './utils/browser';
 import { getElement, getElements, matches, toggleClass } from './utils/elements';
 import { off, on, once, toggleListener, triggerEvent } from './utils/events';
 import is from './utils/is';
+import { silencePromise } from './utils/promise';
 import { getAspectRatio, setAspectRatio } from './utils/style';
 
 class Listeners {
@@ -99,7 +100,7 @@ class Listeners {
                 case 75:
                     // Space and K key
                     if (!repeat) {
-                        player.togglePlay();
+                        silencePromise(player.togglePlay());
                     }
                     break;
 
@@ -431,9 +432,9 @@ class Listeners {
 
                 if (player.ended) {
                     this.proxy(event, player.restart, 'restart');
-                    this.proxy(event, player.play, 'play');
+                    this.proxy(event, () => { silencePromise(player.play()) }, 'play');
                 } else {
-                    this.proxy(event, player.togglePlay, 'play');
+                    this.proxy(event, () => { silencePromise(player.togglePlay()) }, 'play');
                 }
             });
         }
@@ -539,7 +540,7 @@ class Listeners {
         // Play/pause toggle
         if (elements.buttons.play) {
             Array.from(elements.buttons.play).forEach(button => {
-                this.bind(button, 'click', player.togglePlay, 'play');
+                this.bind(button, 'click', () => { silencePromise(player.togglePlay()) }, 'play');
             });
         }
 
@@ -681,7 +682,7 @@ class Listeners {
             // If we're done seeking and it was playing, resume playback
             if (play && done) {
                 seek.removeAttribute(attribute);
-                player.play();
+                silencePromise(player.play());
             } else if (!done && player.playing) {
                 seek.setAttribute(attribute, '');
                 player.pause();

--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -11,6 +11,7 @@ import { triggerEvent } from '../utils/events';
 import i18n from '../utils/i18n';
 import is from '../utils/is';
 import loadScript from '../utils/load-script';
+import { silencePromise } from '../utils/promise';
 import { formatTime } from '../utils/time';
 import { buildUrlParams } from '../utils/urls';
 
@@ -510,7 +511,7 @@ class Ads {
         this.playing = false;
 
         // Play video
-        this.player.media.play();
+        silencePromise(this.player.media.play());
     }
 
     /**

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -27,6 +27,7 @@ import is from './utils/is';
 import loadSprite from './utils/load-sprite';
 import { clamp } from './utils/numbers';
 import { cloneDeep, extend } from './utils/objects';
+import { silencePromise } from './utils/promise';
 import { getAspectRatio, reduceAspectRatio, setAspectRatio, validateRatio } from './utils/style';
 import { parseUrl } from './utils/urls';
 
@@ -303,7 +304,7 @@ class Plyr {
 
         // Autoplay if required
         if (this.isHTML5 && this.config.autoplay) {
-            setTimeout(() => this.play(), 10);
+            setTimeout(() => silencePromise(this.play()), 10);
         }
 
         // Seek time will be recorded (in listeners.js) so we can prevent hiding controls for a few seconds after seek
@@ -356,7 +357,7 @@ class Plyr {
 
         // Intecept play with ads
         if (this.ads && this.ads.enabled) {
-            this.ads.managerPromise.then(() => this.ads.play()).catch(() => this.media.play());
+            this.ads.managerPromise.then(() => this.ads.play()).catch(() => silencePromise(this.media.play()));
         }
 
         // Return the promise (for HTML5)

--- a/src/js/utils/promise.js
+++ b/src/js/utils/promise.js
@@ -1,0 +1,27 @@
+/**
+ * Returns whether an object is `Promise`-like (i.e. has a `then` method).
+ *
+ * @param  {Object}  value
+ *         An object that may or may not be `Promise`-like.
+ *
+ * @return {boolean}
+ *         Whether or not the object is `Promise`-like.
+ */
+export function isPromise(value) {
+    return value !== undefined && value !== null && typeof value.then === 'function';
+}
+
+/**
+ * Silence a Promise-like object.
+ *
+ * This is useful for avoiding non-harmful, but potentially confusing "uncaught
+ * play promise" rejection error messages.
+ *
+ * @param  {Object} value
+ *         An object that may or may not be `Promise`-like.
+ */
+export function silencePromise(value) {
+    if (isPromise(value)) {
+        value.then(null, () => {});
+    }
+}


### PR DESCRIPTION
This pull request is related to or fixes #1216, #1623 & #1581.
It tries to silence all promises of internal `media.play()` calls. This is needed because the internal calls can not be catched by users and thus spam error reporting tools like sentry with unnecessary errors.

This does not change the return values of `play()` or `togglePlay()`, so to fully suppress the uncaught promise exceptions users still have to catch the promises from these two.

### Summary of proposed changes
* Added `utils/promise.js` which was shamelessly copied from [video.js](https://github.com/videojs/video.js/blob/master/src/js/utils/promise.js)
* Silence all internal `play()` promises
* Add the promise footnote to `togglePlay()` in the readme

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
