### PR TITLE
Improve support for linear ads (fixes #1746)

### DIFF
--- a/src/js/plugins/ads.js
+++ b/src/js/plugins/ads.js
@@ -325,11 +325,28 @@ class Ads {
 
                 // Start countdown
                 this.pollCountdown(true);
-
+                
                 if (!ad.isLinear()) {
                     // Position AdDisplayContainer correctly for overlay
                     ad.width = container.offsetWidth;
                     ad.height = container.offsetHeight;
+                    if(ad.getDuration() == -1){
+	                    //means a banner under page
+	                     this.elements.container.style.zIndex = 3;
+	                     //stop countdown don't need it any more
+	                     this.pollCountdown();
+	                     //adjust height of location sho controls remain usable
+						//maybe need nicer names for it... 
+						if(ad.width > 480){
+							var controlHeight = 40;
+						}else{
+							var controlHeight = 60;
+						}
+						
+						ad.height = container.offsetHeight - controlHeight;
+	                     	//adjust them
+	                     	this.elements.displayContainer.setSize(ad.width,ad.height);
+					}
                 }
 
                 // console.info('Ad type: ' + event.getAd().getAdPodInfo().getPodIndex());

--- a/src/sass/plugins/ads.scss
+++ b/src/sass/plugins/ads.scss
@@ -21,7 +21,7 @@
         width: 100%;
     }
 
-    // The countdown label
+    // The countdown label hide it by default
     &::after {
         background: rgba($plyr-color-gray-9, 0.8);
         border-radius: 2px;
@@ -34,8 +34,11 @@
         position: absolute;
         right: $plyr-control-spacing;
         z-index: 3;
+        display: none;
     }
-
+    &[data-badge-text]:after{
+	    display: block;
+    }
     &::after:empty {
         display: none;
     }


### PR DESCRIPTION
### Link to related issue (if applicable)
#1746

### Summary of proposed changes
Changed few lines for non Linear Ads played during video it self. Before the ads event are trigged how ever the z-index was removed during resumeContent();

This will be added again.

Disable pollCountdown when this kind of add is loaded and hide the bubble

Last I moved the advertisement a few pixels up by default maybe should be changed later on that this only happen when controls are enabled?

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
Tested on Chrome, Safari. Unable to test on Windows...
