### PR TITLE
init options bug

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -179,7 +179,7 @@ const captions = {
             // When passive, don't override user preferences
             if (!passive) {
                 this.captions.active = active;
-                this.storage.set({ captions: active });
+                this.storage.set({ captions: this.captions });
             }
 
             // Force language if the call isn't passive and there is no matching language to toggle to

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -479,7 +479,7 @@ class Listeners {
             controls.updateSetting.call(player, 'speed');
 
             // Save to storage
-            player.storage.set({ speed: player.speed });
+            player.storage.set({ speed: player.config.speed });
         });
 
         // Quality change

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -6,9 +6,9 @@ import is from './utils/is';
 import { extend } from './utils/objects';
 
 class Storage {
-    constructor(player) {
-        this.enabled = player.config.storage.enabled;
-        this.key = player.config.storage.key;
+    constructor(enabled, key) {
+        this.enabled = enabled;
+        this.key = key;
     }
 
     // Check for actual support (see if we can use it)

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -61,20 +61,12 @@ const ui = {
             captions.setup.call(this);
         }
 
-        // Reset volume
-        this.volume = null;
-
-        // Reset mute state
-        this.muted = null;
-
-        // Reset loop state
-        this.loop = null;
-
-        // Reset quality setting
-        this.quality = null;
-
-        // Reset speed
-        this.speed = null;
+        // set volume, mute, loop, quality, speed
+        this.volume = this.config.volume;
+        this.muted = this.config.muted;
+        this.loop = this.config.loop;
+        this.quality = this.config.quality;
+        this.speed = this.config.speed;
 
         // Reset volume display
         controls.updateVolume.call(this);

--- a/src/js/utils/normalize-options.js
+++ b/src/js/utils/normalize-options.js
@@ -1,0 +1,18 @@
+export default function(options, defaults) {
+  if (!options) {
+    return defaults;
+  }
+
+  const normalizedOptions = {};
+
+  Object.keys(defaults)
+    .forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(options, key)) {
+        normalizedOptions[key] = options[key];
+      } else {
+        normalizedOptions[key] = defaults[key];
+      }
+    });
+
+  return normalizedOptions;
+}

--- a/src/js/utils/objects.js
+++ b/src/js/utils/objects.js
@@ -28,10 +28,7 @@ export function extend(target = {}, ...sources) {
 
     Object.keys(source).forEach(key => {
         if (is.object(source[key])) {
-            if (!Object.keys(target).includes(key)) {
-                Object.assign(target, { [key]: {} });
-            }
-
+            Object.assign(target, { [key]: {} });
             extend(target[key], source[key]);
         } else {
             Object.assign(target, { [key]: source[key] });


### PR DESCRIPTION
### Link to related issue (if applicable)
#1737 

### Summary of proposed changes
this PR helps in prioritizing the config provided by the User, rather than applying values from local storage, the high priority is given to 

- `user-config`
- `local-storage`
- `app's default config`

it also normalizes options such as quality and speed such that if the user forgets to input one of the required fields it uses app's default config for that field

this code has been tested with `HTML5`, `Youtube` and `Vimeo` and works without issues 

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
**testing in progress**
