### PR TITLE
Preload TextTracks as per default video element

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -133,8 +133,12 @@ const captions = {
                     });
 
                     // Turn off native caption rendering to avoid double captions
+                    // Note: mode='hidden' forces a track to download. To ensure every track
+                    // isn't downloaded at once, only 'showing' tracks should be reassigned
                     // eslint-disable-next-line no-param-reassign
-                    track.mode = 'hidden';
+                    if (track.mode === 'showing') {
+                        track.mode = 'hidden';
+                    }
 
                     // Add event listener for cue changes
                     on.call(this, track, 'cuechange', () => captions.updateCues.call(this));
@@ -211,6 +215,14 @@ const captions = {
             // Trigger event (not used internally)
             triggerEvent.call(this, this.media, active ? 'captionsenabled' : 'captionsdisabled');
         }
+
+        // Wait for the call stack to clear before setting mode='hidden'
+        // on the active track - forcing the browser to download it
+        setTimeout(() => {
+            if (active && this.captions.toggled) {
+                this.captions.currentTrackNode.mode = 'hidden';
+            }   
+        });
     },
 
     // Set captions by track index


### PR DESCRIPTION
### Link to related issue (if applicable)
#1791

### Summary of proposed changes
These changes bring Plyr captions download behaviour in line with that of the default video element in major browsers. Specifically, text tracks now only download as they are required. Previously all text tracks would download when the Plyr instance was instantiated - which becomes an issue when e.g. many translations are available.

For a track to be downloaded it must either be the default track, the active track when captions are toggled on, or selected from the captions menu.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
