### PR TITLE
allow custom control as element

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1263,7 +1263,7 @@ const controls = {
     this.elements.controls = null;
 
     // Larger overlaid play button
-    if (this.config.controls.includes('play-large')) {
+    if (is.array(this.config.controls) && this.config.controls.includes('play-large')) {
       this.elements.container.appendChild(createButton.call(this, 'play-large'));
     }
 
@@ -1275,7 +1275,7 @@ const controls = {
     const defaultAttributes = { class: 'plyr__controls__item' };
 
     // Loop through controls in order
-    dedupe(this.config.controls).forEach(control => {
+    dedupe(is.array(this.config.controls) ? this.config.controls: []).forEach(control => {
       // Restart button
       if (control === 'restart') {
         container.appendChild(createButton.call(this, 'restart', defaultAttributes));
@@ -1675,8 +1675,6 @@ const controls = {
     if (update) {
       if (is.string(this.config.controls)) {
         container = replace(container);
-      } else if (is.element(container)) {
-        container.innerHTML = replace(container.innerHTML);
       }
     }
 

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -1054,7 +1054,7 @@ class Plyr {
       const hiding = toggleClass(this.elements.container, this.config.classNames.hideControls, force);
 
       // Close menu
-      if (hiding && this.config.controls.includes('settings') && !is.empty(this.config.settings)) {
+      if (hiding && is.array(this.config.controls) && this.config.controls.includes('settings') && !is.empty(this.config.settings)) {
         controls.toggleMenu.call(this, false);
       }
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes

We create custom control, but would like to maintain control element out of plyr.
1. check places where control is passed as "element"
2. don't replace innerHTML. that will get rid of the existing event listener maintained externally.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
