### PR TITLE
force fullscreen events to trigger on plyr element

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -145,8 +145,10 @@ class Fullscreen {
       button.pressed = this.active;
     }
 
+    // Always trigger events on the plyr / media element (not a fullscreen container) and let them bubble up
+    const target = this.target === this.player.media ? this.target : this.player.elements.container;
     // Trigger an event
-    triggerEvent.call(this.player, this.target, this.active ? 'enterfullscreen' : 'exitfullscreen', true);
+    triggerEvent.call(this.player, target, this.active ? 'enterfullscreen' : 'exitfullscreen', true);
   }
 
   toggleFallback(toggle = false) {


### PR DESCRIPTION
When you specify a fullscreen container element, fullscreen events currently originate on this element. This PR forces the events to originate on the Plyr container element (or the media element in iOS).

Events will still bubble up to any fullscreen containers.

### Link to related issue (if applicable)
#1758 

### Summary of proposed changes

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
