### PR TITLE
Update video.scss

### DIFF
--- a/src/sass/types/video.scss
+++ b/src/sass/types/video.scss
@@ -5,7 +5,6 @@
 // Container
 .plyr--video {
   background: #000;
-  overflow: hidden;
 
   &.plyr--menu-open {
     overflow: visible;
@@ -63,7 +62,7 @@ $embed-padding: ((100 / 16) * 9);
   padding-top: calc(#{$plyr-control-spacing} * 2);
   position: absolute;
   right: 0;
-  transition: opacity 0.4s ease-in-out, transform 0.4s ease-in-out;
+  transition: opacity 0.4s ease-in-out;
   z-index: 3;
 
   @media (min-width: $plyr-bp-sm) {
@@ -76,7 +75,6 @@ $embed-padding: ((100 / 16) * 9);
 .plyr--video.plyr--hide-controls .plyr__controls {
   opacity: 0;
   pointer-events: none;
-  transform: translateY(100%);
 }
 
 // Control elements


### PR DESCRIPTION
### Link to related issue (if applicable)
#1890 
https://github.com/sampotts/plyr/issues/1266#issuecomment-464867614

### Summary of proposed changes
The fullscreen video will be cropped 1/4 on safari when users are not using the actual size (the browser has been zoomed in or out) or the laptop is Retina display.
To fix the issue, I removed the `overflow: hidden` for the `plyr--video` class and transform animation for controls.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
