### PR TITLE
Fix PreviewThumbnailsOptions type

### DIFF
--- a/src/js/plyr.d.ts
+++ b/src/js/plyr.d.ts
@@ -552,7 +552,7 @@ declare namespace Plyr {
 
   interface PreviewThumbnailsOptions {
     enabled?: boolean;
-    src?: string;
+    src?: string | string[];
   }
 
   interface SourceInfo {


### PR DESCRIPTION


### Link to related issue (if applicable)

### Summary of proposed changes

According to the docs, the `src` should also accept an array of strings.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
