### PR TITLE
Check if key is a string before attempt --plyr checking

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -270,7 +270,7 @@ const ui = {
     // Loop through values (as they are the keys when the object is spread 🤔)
     Object.values({ ...this.media.style })
       // We're only fussed about Plyr specific properties
-      .filter(key => !is.empty(key) && key.startsWith('--plyr'))
+      .filter(key => !is.empty(key) && is.string(key) && key.startsWith('--plyr'))
       .forEach(key => {
         // Set on the container
         this.elements.container.style.setProperty(key, this.media.style.getPropertyValue(key));


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1915

### Summary of proposed changes
Do a simple is.string checking before attempt checking against --plyr string during migrateStyles

### Checklist
- [/ ] Use `develop` as the base branch
- [/ ] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
