### PR TITLE
Fix for Slow loading videos not autoplaying

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -308,7 +308,7 @@ class Plyr {
 
     // Autoplay if required
     if (this.isHTML5 && this.config.autoplay) {
-      this.on('canplay', () => silencePromise(this.play()));
+      this.once('canplay', () => silencePromise(this.play()));
     }
 
     // Seek time will be recorded (in listeners.js) so we can prevent hiding controls for a few seconds after seek

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -308,7 +308,7 @@ class Plyr {
 
     // Autoplay if required
     if (this.isHTML5 && this.config.autoplay) {
-      setTimeout(() => silencePromise(this.play()), 10);
+      this.on('canplay', () => silencePromise(this.play()));
     }
 
     // Seek time will be recorded (in listeners.js) so we can prevent hiding controls for a few seconds after seek
@@ -1054,7 +1054,12 @@ class Plyr {
       const hiding = toggleClass(this.elements.container, this.config.classNames.hideControls, force);
 
       // Close menu
-      if (hiding && is.array(this.config.controls) && this.config.controls.includes('settings') && !is.empty(this.config.settings)) {
+      if (
+        hiding &&
+        is.array(this.config.controls) &&
+        this.config.controls.includes('settings') &&
+        !is.empty(this.config.settings)
+      ) {
         controls.toggleMenu.call(this, false);
       }
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
For slow loading video the video will not autoplay as the video has not yet loaded


### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
