### PR TITLE
Fix for apect ratio problem when using Vimeo player on mobile devices…

### DIFF
--- a/src/js/utils/style.js
+++ b/src/js/utils/style.js
@@ -68,7 +68,11 @@ export function setAspectRatio(input) {
     const height = (100 / this.media.offsetWidth) * parseInt(window.getComputedStyle(this.media).paddingBottom, 10);
     const offset = (height - padding) / (height / 50);
 
-    this.media.style.transform = `translateY(-${offset}%)`;
+    if(this.fullscreen.active) {
+      wrapper.style.paddingBottom = null;
+    } else {
+      this.media.style.transform = `translateY(-${offset}%)`;
+    }
   } else if (this.isHTML5) {
     wrapper.classList.toggle(this.config.classNames.videoFixedRatio, ratio !== null);
   }


### PR DESCRIPTION
### Link to related issue (if applicable)
#1940 
### Summary of proposed changes
Just added additional check for fullscreen resolution and reset padding
### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
