### PR TITLE
Fix volume when unmuting from volume 0

### DIFF
--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -278,6 +278,7 @@ const youtube = {
               const toggle = is.boolean(input) ? input : muted;
               muted = toggle;
               instance[toggle ? 'mute' : 'unMute']();
+              instance.setVolume(volume * 100);
               triggerEvent.call(player, player.media, 'volumechange');
             },
           });


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1934

### Summary of proposed changes
The youtube api when unmute reset the volume automatically to arount 20%

The reproduce the problem, follow the step in the issue 
How to reproduce bug:

go on https://plyr.io/#youtube
drag volume slider to 0
refresh the page
play the video

### Checklist
- [X] Use `develop` as the base branch
- [X] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
