### PR TITLE
Add missing unit to calc in media query

### DIFF
--- a/src/sass/components/times.scss
+++ b/src/sass/components/times.scss
@@ -14,7 +14,7 @@
     margin-right: $plyr-control-spacing;
   }
 
-  @media (max-width: calc(#{$plyr-bp-md} - 1)) {
+  @media (max-width: calc(#{$plyr-bp-md} - 1px)) {
     display: none;
   }
 }


### PR DESCRIPTION
### Summary of proposed changes
Added unit to `calc()` to help interpretation.

I've run into some issues interpreting mixed units in `calc()` inside media queries using [CSSO](https://github.com/css/csso) and [postcss-calc](https://github.com/postcss/postcss-calc). postcss-calc ignores mixed units and csso can’t interpret mixed units. I guess this should be an issue I propos to csso, and I will, but I also think that we should add the missing unit here for a more simple calculation :)

Thanks for the best player out there! <3

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
