### PR TITLE
Prevent immediate hiding of controls on mobile when using rewind and fast forward

### DIFF
--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -569,10 +569,18 @@ class Listeners {
     this.bind(elements.buttons.restart, 'click', player.restart, 'restart');
 
     // Rewind
-    this.bind(elements.buttons.rewind, 'click', player.rewind, 'rewind');
+    this.bind(elements.buttons.rewind, 'click', () => {
+      // Record seek time so we can prevent hiding controls for a few seconds after rewind
+      player.lastSeekTime = Date.now();
+      player.rewind();
+    }, 'rewind');
 
     // Rewind
-    this.bind(elements.buttons.fastForward, 'click', player.forward, 'fastForward');
+    this.bind(elements.buttons.fastForward, 'click', () => {
+      // Record seek time so we can prevent hiding controls for a few seconds after fast forward
+      player.lastSeekTime = Date.now();
+      player.forward();
+    }, 'fastForward');
 
     // Mute toggle
     this.bind(


### PR DESCRIPTION
### Link to related issue (if applicable)
This PR continues #1226 which concerned preventing immediately hiding of controls on mobile after seek, but this time it's about using rewind and fast forward GUI buttons.

### Summary of proposed changes

Current behaviour: when a touch device user taps the rewind/fast forward button, the controls disappear immediately. Similar behaviour with using seek bar was previously resolved by #1226.

Solution: use the same mechanism implemented by #1226 which is to assign player's lastSeekTime to prevent controls hiding for 2 seconds.

### Checklist

- [x] Use `develop` as the base branch
- [x] Exclude the gulp build from the PR
- [x] Test on supported browsers
