### PR TITLE
Fix youtube not working when player is inside shadow dom

### DIFF
--- a/src/js/plugins/youtube.js
+++ b/src/js/plugins/youtube.js
@@ -147,7 +147,7 @@ const youtube = {
 
     // Setup instance
     // https://developers.google.com/youtube/iframe_api_reference
-    player.embed = new window.YT.Player(id, {
+    player.embed = new window.YT.Player(player.media, {
       videoId,
       host: getHost(config),
       playerVars: extend(


### PR DESCRIPTION
### Summary of proposed changes
Youtube videos doesn't work when plyr is inside shadow dom (web components is an example of this use case). It happens because youtube creates an instance of its player using element id, and presumably unable to find it.

Proposal is to use element reference instead of id. This way it works in both plain and shadow dom.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support) (tested on Chrome and Safari)
