### PR TITLE
Fixes #2005

### DIFF
--- a/src/sass/components/volume.scss
+++ b/src/sass/components/volume.scss
@@ -15,6 +15,7 @@
     margin-right: calc(#{$plyr-control-spacing} / 2);
     position: relative;
     z-index: 2;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
### Link to related issue (if applicable)

#2005

### Summary of proposed changes

Add a minimum width to the input element that controls the volume. This fixes an issue in Firefox, where the intrinsic minimum width of the browser can be larger than the available space. Tested on Firefox and Chrome. 

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [ ] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
