### PR TITLE
Add container over volume input range

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1372,6 +1372,8 @@ const controls = {
         // Ignored on iOS as it's handled globally
         // https://developer.apple.com/library/safari/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/Device-SpecificConsiderations/Device-SpecificConsiderations.html
         if (control === 'volume' && !browser.isIos) {
+          const volumeContainer = createElement('div', {});
+
           // Set the attributes
           const attributes = {
             max: 1,
@@ -1379,8 +1381,10 @@ const controls = {
             value: this.config.volume,
           };
 
+          this.elements.volumeContainer = volumeContainer;
+
           // Create the volume range slider
-          volume.appendChild(
+          volumeContainer.appendChild(
             createRange.call(
               this,
               'volume',
@@ -1389,6 +1393,8 @@ const controls = {
               }),
             ),
           );
+
+          volume.appendChild(volumeContainer);
         }
       }
 

--- a/src/sass/components/volume.scss
+++ b/src/sass/components/volume.scss
@@ -11,8 +11,8 @@
   width: 20%;
 
   input[type='range'] {
-    margin-left: calc(#{$plyr-control-spacing} / 2);
-    margin-right: calc(#{$plyr-control-spacing} / 2);
+    padding-left: calc(#{$plyr-control-spacing} / 2);
+    padding-right: calc(#{$plyr-control-spacing} / 5);
     position: relative;
     z-index: 2;
   }


### PR DESCRIPTION
- Fix bug in Firefox where volume input range stays over the download buttom

### Link to related issue (if applicable)

### Summary of proposed changes
Fix bug in Firefox where volume input range stays over the download buttom
![FirefoxBug](https://user-images.githubusercontent.com/47041988/100364844-67c25900-2fdd-11eb-8242-057e3bcdab97.jpg)

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
