### PR TITLE
Fix issue with not entering iosfullscreen of vimeo videos with playsi…

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -254,7 +254,11 @@ class Fullscreen {
 
     // iOS native fullscreen doesn't need the request step
     if (browser.isIos && this.player.config.fullscreen.iosNative) {
-      this.target.webkitEnterFullscreen();
+      if (this.player.provider === 'vimeo') {
+        this.player.embed.requestFullscreen();
+      } else {
+        this.target.webkitEnterFullscreen();
+      }
     } else if (!Fullscreen.native || this.forceFallback) {
       this.toggleFallback(true);
     } else if (!this.prefix) {

--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -254,7 +254,7 @@ class Fullscreen {
 
     // iOS native fullscreen doesn't need the request step
     if (browser.isIos && this.player.config.fullscreen.iosNative) {
-      if (this.player.provider === 'vimeo') {
+      if (this.player.isVimeo) {
         this.player.embed.requestFullscreen();
       } else {
         this.target.webkitEnterFullscreen();


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1988

### Summary of proposed changes
When using vimeo the video gets embedded as iframe instead of HTML5 player. Since `webkitEnterFullscreen()` is defined on HTML5 player only, we have to use `requestFullscreen()` on the embed element.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
