### PR TITLE
Remove unnecessary calc() from media query

### DIFF
--- a/src/sass/components/times.scss
+++ b/src/sass/components/times.scss
@@ -14,7 +14,7 @@
     margin-right: $plyr-control-spacing;
   }
 
-  @media (max-width: calc(#{$plyr-bp-md} - 1px)) {
+  @media (max-width: ($plyr-bp-md - 1px)) {
     display: none;
   }
 }


### PR DESCRIPTION
### Summary of proposed changes
I've ran into issues compiling my styling using the `gulp-group-css-media-queries` plugin:
![image](https://user-images.githubusercontent.com/29675763/102333046-2a723b00-3f8d-11eb-8add-378d38983341.png)

I discovered the error was in `times.scss`, specifically the line where the media query uses `calc()`. Removing `calc()` solved the compiling error. I guess this should also be fixed in the `gulp-group-css-media-queries` plugin, but since this particular media query works just fine without the `calc()`, I went ahead and removed it :)

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
