### PR TITLE
FIX - object values of the providers object must be used

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -206,7 +206,7 @@ class Plyr {
         }
 
         // Unsupported or missing provider
-        if (is.empty(this.provider) || !Object.keys(providers).includes(this.provider)) {
+        if (is.empty(this.provider) || !Object.values(providers).includes(this.provider)) {
           this.debug.error('Setup failed: Invalid provider');
           return;
         }


### PR DESCRIPTION
To make use of the provider configuration, the objects values must be used.

### Link to related issue (if applicable)

### Summary of proposed changes

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
