### PR TITLE
Fix invisible poster in Safari

### DIFF
--- a/src/sass/types/video.scss
+++ b/src/sass/types/video.scss
@@ -19,6 +19,7 @@
   overflow: hidden;
   position: relative;
   width: 100%;
+  z-index: inherit;
 }
 
 // Default to 16:9 ratio but this is set by JavaScript based on config


### PR DESCRIPTION
### Link to related issue (if applicable)
#2064 
### Summary of proposed changes
Safari needs to have a set `z-index` on `.plyr__video-wrapper` to not hide the poster image, so we inherit `z-index` from `.plyr`with the value of `0`.
### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
