### PR TITLE
Fix to work inside iframes.

### DIFF
--- a/src/js/utils/is.js
+++ b/src/js/utils/is.js
@@ -21,6 +21,7 @@ const isTrack = (input) => instanceOf(input, TextTrack) || (!isNullOrUndefined(i
 const isPromise = (input) => instanceOf(input, Promise) && isFunction(input.then);
 
 const isElement = (input) =>
+  input !== null && 
   (typeof input === "object") &&
   (input.nodeType === 1) &&
   (typeof input.style === "object") &&

--- a/src/js/utils/is.js
+++ b/src/js/utils/is.js
@@ -13,13 +13,18 @@ const isFunction = (input) => getConstructor(input) === Function;
 const isArray = (input) => Array.isArray(input);
 const isWeakMap = (input) => instanceOf(input, WeakMap);
 const isNodeList = (input) => instanceOf(input, NodeList);
-const isElement = (input) => instanceOf(input, Element);
 const isTextNode = (input) => getConstructor(input) === Text;
 const isEvent = (input) => instanceOf(input, Event);
 const isKeyboardEvent = (input) => instanceOf(input, KeyboardEvent);
 const isCue = (input) => instanceOf(input, window.TextTrackCue) || instanceOf(input, window.VTTCue);
 const isTrack = (input) => instanceOf(input, TextTrack) || (!isNullOrUndefined(input) && isString(input.kind));
 const isPromise = (input) => instanceOf(input, Promise) && isFunction(input.then);
+
+const isElement = (input) =>
+  (typeof input === "object") &&
+  (input.nodeType === 1) &&
+  (typeof input.style === "object") &&
+  (typeof input.ownerDocument === "object");
 
 const isEmpty = (input) =>
   isNullOrUndefined(input) ||


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
Right now Plyr fails to load inside iframes because the selectors are not instances of Element (iframes have their own, separate globals). This is an alternative method to check isElement that will work inside iframes. This is battle-tested fallback code used before browsers supported HTMLElement.

### Checklist
- [x] Use `develop` as the base branch
- [x] Exclude the gulp build (`/dist` changes) from the PR
- [x] Test on [supported browsers](https://github.com/sampotts/plyr#browser-support)
