### PR TITLE
Fix errors when Plyr destroyed before setTimeout() executes

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -154,7 +154,9 @@ const captions = {
     }
 
     // Enable or disable captions based on track length
-    toggleClass(this.elements.container, this.config.classNames.captions.enabled, !is.empty(tracks));
+    if (this.elements) {
+      toggleClass(this.elements.container, this.config.classNames.captions.enabled, !is.empty(tracks));
+    }
 
     // Update available languages in list
     if (

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -675,7 +675,9 @@ class Plyr {
 
     // Set media speed
     setTimeout(() => {
-      this.media.playbackRate = speed;
+      if (this.media) {
+        this.media.playbackRate = speed;
+      }
     }, 0);
   }
 


### PR DESCRIPTION
Fixed errors when Plyr instance is destroyed before constructor setTimeout() functions execute.

### The issue

We see these errors when we create and destroy a Plyr instance very quickly:

![plyr-error-stack-captions-update](https://user-images.githubusercontent.com/78907189/107630356-0faa0300-6c6c-11eb-8430-474a3bcf07e4.png)
![plyr-error-stack-constructor-set-speed](https://user-images.githubusercontent.com/78907189/107630362-120c5d00-6c6c-11eb-85e3-78bc9e1968a2.png)

Also in some cases the video keeps playing in the background.

Some context:

We are building a React app with a slideshow-like interface. Only the visible slide contents are rendered. Some slides contain Plyr instances that are created in `componentDidMount()` and destroyed in `componentWillUnmount()`.

We noticed that when a user navigates a slideshow very quickly (e.g. via keyboard), the audio from a video in one of the slides keeps playing. We also get the errors in the DevTools console (screenshots above).

### Summary of proposed changes

I just added the checks if the values are truthy, before assigning properties to them.