### PR TITLE
Use prefix for custom event names

### DIFF
--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -86,9 +86,14 @@ export function triggerEvent(element, type = '', bubbles = false, detail = {}) {
   if (!is.element(element) || is.empty(type)) {
     return;
   }
+  // error event should not bubble and break error tracking tools
+  // https://developer.mozilla.org/en-US/docs/Web/API/Element/error_event
+  if (type === 'error') {
+    bubbles = false;
+  }
 
   // Create and dispatch the event
-  const event = new CustomEvent('plyr:' + type, {
+  const event = new CustomEvent(type, {
     bubbles,
     detail: { ...detail, plyr: this },
   });

--- a/src/js/utils/events.js
+++ b/src/js/utils/events.js
@@ -88,7 +88,7 @@ export function triggerEvent(element, type = '', bubbles = false, detail = {}) {
   }
 
   // Create and dispatch the event
-  const event = new CustomEvent(type, {
+  const event = new CustomEvent('plyr:' + type, {
     bubbles,
     detail: { ...detail, plyr: this },
   });

--- a/src/js/utils/fetch.js
+++ b/src/js/utils/fetch.js
@@ -26,7 +26,7 @@ export default function fetch(url, responseType = 'text') {
       });
 
       request.addEventListener('error', () => {
-        throw new Error(request.status);
+        reject(new Error(request.status));
       });
 
       request.open('GET', url, true);


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/1581
https://github.com/sampotts/plyr/issues/1623

### Summary of proposed changes
At present function `triggerEvent` dispatches `CustomEvent` with name in `type` argument. In some cases such events conflict with system ones because use the same name. As a result folks could have weird error records in their reporting tools.

For instance the [`error` event](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror) used to collect all information about errors on page. This event has defined structure and additional fields like `source`, `lineno` etc. But `CustomEvent` with the same name could be dispatched at https://github.com/sampotts/plyr/blob/master/src/js/listeners.js#L515. As the result depended event listeners could fail and display weird results.

The change in PR adds prefix to all dispatched `CustomEvent`s to avoid any naming conflicts with existing events. I'm not sure about potential consequences of this so let me know if any.