### PR TITLE
Fix z-indexes on Youtube controls

### DIFF
--- a/src/sass/components/poster.scss
+++ b/src/sass/components/poster.scss
@@ -20,3 +20,11 @@
 .plyr--stopped.plyr__poster-enabled .plyr__poster {
   opacity: 1;
 }
+
+.plyr__poster-enabled.plyr--paused .plyr__poster {
+	z-index: -1;
+}
+
+.plyr__poster-enabled .plyr__poster {
+	z-index: -1;
+}


### PR DESCRIPTION
On Youtube videos, the "copy link" and browsing "more videos" don't work due to the wrong z-index.
![screenshot-biati-digital github io-2021 03 15-10_19_51](https://user-images.githubusercontent.com/3611726/111211968-55414f00-85cf-11eb-9e27-0d9599fac9e2.png)

### Link to related issue (if applicable)
Encountered in Glightbox: https://github.com/biati-digital/glightbox/issues/214

### Summary of proposed changes
Change z-indexes.

