### PR TITLE
typings: Add FullscreenOptions.container to typing files

### DIFF
--- a/src/js/plyr.d.ts
+++ b/src/js/plyr.d.ts
@@ -549,6 +549,7 @@ declare namespace Plyr {
     fallback?: boolean | 'force';
     allowAudio?: boolean;
     iosNative?: boolean;
+    container?: string;
   }
 
   interface CaptionOptions {


### PR DESCRIPTION
### Summary of proposed changes

Added `container?: string` property to `FullscreenOptions`

### Reason for changes

The typing file was missing the `FullscreenOptions.container` property, added in this PR: https://github.com/sampotts/plyr/pull/1759


I discovered this missing property as I needed to use a fullscreen overlay with plyr & typescript. I have confirmed that this change fixes the typing issue that was being experienced.