### PR TITLE
fix: youtube poster allow clickthrough while paused

### DIFF
--- a/src/sass/components/poster.scss
+++ b/src/sass/components/poster.scss
@@ -20,3 +20,8 @@
 .plyr--stopped.plyr__poster-enabled .plyr__poster {
   opacity: 1;
 }
+
+// Allow interaction with YouTube controls while paused
+.plyr--youtube.plyr--paused.plyr__poster-enabled:not(.plyr--stopped) .plyr__poster {
+  display: none;
+}


### PR DESCRIPTION
### Link to related issue (if applicable)

#1833

### Summary of proposed changes

- Hides the poster image while paused (but not stopped) enabling the user to interact with YouTube elements 