### PR TITLE
change fullscreen element to player rootnode

### DIFF
--- a/src/js/fullscreen.js
+++ b/src/js/fullscreen.js
@@ -124,7 +124,7 @@ class Fullscreen {
       return hasClass(this.target, this.player.config.classNames.fullscreen.fallback);
     }
 
-    const element = !this.prefix ? document.fullscreenElement : document[`${this.prefix}${this.property}Element`];
+    const element = !this.prefix ? this.target.getRootNode().fullscreenElement : this.target.getRootNode()[`${this.prefix}${this.property}Element`];
 
     return element && element.shadowRoot ? element === this.target.getRootNode().host : element === this.target;
   }


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
Using 'plyr' in a web-component breaks the full-screen feature as the web-component's shadow-root will carry the fullscreenElement instead of the fullscreenElement of document.

