### PR TITLE
(fix): youtube videos duration (ref #2223).

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -82,6 +82,9 @@ const ui = {
     // Reset time display
     controls.timeUpdate.call(this);
 
+    // Reset duration display
+    controls.durationUpdate.call(this);
+
     // Update the UI
     ui.checkPlaying.call(this);
 


### PR DESCRIPTION
### Link to related issue (if applicable)
#2223 

### Summary of proposed changes
Fixing the problem where duration for youtube videos is displayed as `00:00`. 