### PR TITLE
Let icons load in iframes without a location

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -38,7 +38,8 @@ const controls = {
   // Get icon URL
   getIconUrl() {
     const url = new URL(this.config.iconUrl, window.location);
-    const cors = url.host !== window.location.host || (browser.isIE && !window.svg4everybody);
+    const host = window.location.host ? window.location.host : window.top.location.host;
+    const cors = url.host !== host || (browser.isIE && !window.svg4everybody);
 
     return {
       url: this.config.iconUrl,


### PR DESCRIPTION
### Link to related issue (if applicable)
N/A

### Summary of proposed changes
Currently, icons will fail to load if the player is placed inside an iframe without a window.location. This adds an additional check to use `window.top.location` if the window does not have a location.