### PR TITLE
Fixes iOS fullscreen not centered issue.

### DIFF
--- a/src/sass/types/video.scss
+++ b/src/sass/types/video.scss
@@ -18,6 +18,7 @@
   overflow: hidden;
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 // Default to 16:9 ratio but this is set by JavaScript based on config


### PR DESCRIPTION
Currently, the video is not centered in the iOS full screen.
![IMG_24E34247038E-1](https://user-images.githubusercontent.com/1333346/127002197-4b455b62-347a-4bb6-94c5-00c2a0829be4.jpeg)
