### PR TITLE
update video.scss to use sass:math

### DIFF
--- a/src/sass/types/video.scss
+++ b/src/sass/types/video.scss
@@ -2,6 +2,8 @@
 // Video styles
 // --------------------------------------------------------------
 
+@use 'sass:math';
+
 // Container
 .plyr--video {
   background: var(--plyr-video-background, $plyr-video-background);
@@ -21,7 +23,7 @@
 }
 
 // Default to 16:9 ratio but this is set by JavaScript based on config
-$embed-padding: ((100 / 16) * 9);
+$embed-padding: (math.div(100, 16) * 9);
 
 .plyr__video-embed,
 .plyr__video-wrapper--fixed-ratio {
@@ -47,7 +49,7 @@ $embed-padding: ((100 / 16) * 9);
 // For Vimeo, if the full custom UI is supported
 .plyr--full-ui .plyr__video-embed > .plyr__video-embed__container {
   $height: 240;
-  $offset: to-percentage(($height - $embed-padding) / ($height / 50));
+  $offset: to-percentage(math.div($height - $embed-padding, math.div($height, 50)));
   padding-bottom: to-percentage($height);
   position: relative;
   transform: translateY(-$offset);


### PR DESCRIPTION
### Link to related issue (if applicable)
https://sass-lang.com/documentation/breaking-changes/slash-div

### Summary of proposed changes
Implement the new math.div for divisions that where made in video.scss

DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.