### PR TITLE
Fix invalid CSS selector syntax

### DIFF
--- a/src/sass/plugins/ads.scss
+++ b/src/sass/plugins/ads.scss
@@ -36,7 +36,7 @@
     z-index: 3;
   }
 
-  &::after:empty {
+  &:empty::after {
     display: none;
   }
 }


### PR DESCRIPTION
https://jigsaw.w3.org/css-validator/ complains that "The selector :empty can't appear after the pseudo-element selector ::after". Switching their places, however, will validate.

### Summary of proposed changes
Fix invalid CSS syntax.