### PR TITLE
Vimeo private videos: check for hash in src and add as a param

### DIFF
--- a/src/js/config/defaults.js
+++ b/src/js/config/defaults.js
@@ -398,6 +398,7 @@ const defaults = {
     embed: {
       provider: 'data-plyr-provider',
       id: 'data-plyr-embed-id',
+      hash: 'data-plyr-embed-hash',
     },
   },
 

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -80,6 +80,16 @@ const vimeo = {
       });
     }
 
+    // Get the source URL or ID
+    let source = player.media.getAttribute('src');
+
+    // Check wether there is a hash appended to the given url
+    const regex = /^.*(?:vimeo.com\/|video\/)(?:\d+\/)(?<hash>[\d,a-f]+)$/
+    const found = source.match(regex)
+    const hashParam = (found) ? {
+      h: found.groups.hash
+    } : {}
+
     // Get Vimeo params for the iframe
     const params = buildUrlParams({
       loop: player.config.loop.active,
@@ -87,11 +97,11 @@ const vimeo = {
       muted: player.muted,
       gesture: 'media',
       playsinline: !this.config.fullscreen.iosNative,
+      // hash has to be added to iframe-URL
+      ...hashParam,
       ...frameParams,
     });
 
-    // Get the source URL or ID
-    let source = player.media.getAttribute('src');
 
     // Get from <div> if needed
     if (is.empty(source)) {

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -28,6 +28,25 @@ function parseId(url) {
   return url.match(regex) ? RegExp.$2 : url;
 }
 
+// Try to extract a hash for private videos from the URL
+function parseHash(url) {
+  /* This regex matches a hexadecimal hash if given in any of these forms:
+   *  - [https://player.]vimeo.com/video/{id}/{hash}[?params]
+   *  - [https://player.]vimeo.com/video/{id}?h={hash}[&params]
+   *  - [https://player.]vimeo.com/video/{id}?[params]&h={hash}
+   *  - video/{id}/{hash}
+   * If matched, the hash is available in the named group `hash`
+   */
+  const regex = /^.*(?:vimeo.com\/|video\/)(?:\d+)(?:\?.*\&*h=|\/)+(?<hash>[\d,a-f]+)/
+  const found = url.match(regex)
+
+  if (found) {
+    return found.groups.hash
+  }
+
+  return null
+}
+
 // Set playback state and trigger change (only on actual change)
 function assurePlaybackState(play) {
   if (play && !this.embed.hasPlayed) {
@@ -72,6 +91,19 @@ const vimeo = {
     const config = player.config.vimeo;
     const { premium, referrerPolicy, ...frameParams } = config;
 
+    // Get the source URL or ID
+    let source = player.media.getAttribute('src');
+    let hash = ''
+    // Get from <div> if needed
+    if (is.empty(source)) {
+      source = player.media.getAttribute(player.config.attributes.embed.id);
+      // hash can also be set as attribute on the <div>
+      hash = player.media.getAttribute(player.config.attributes.embed.hash);
+    } else {
+      hash = parseHash(source)
+    }
+    const hashParam = (!!hash) ? {h: hash} : {}
+
     // If the owner has a pro or premium account then we can hide controls etc
     if (premium) {
       Object.assign(frameParams, {
@@ -79,16 +111,6 @@ const vimeo = {
         sidedock: false,
       });
     }
-
-    // Get the source URL or ID
-    let source = player.media.getAttribute('src');
-
-    // Check wether there is a hash appended to the given url
-    const regex = /^.*(?:vimeo.com\/|video\/)(?:\d+\/)(?<hash>[\d,a-f]+)$/
-    const found = source.match(regex)
-    const hashParam = (found) ? {
-      h: found.groups.hash
-    } : {}
 
     // Get Vimeo params for the iframe
     const params = buildUrlParams({
@@ -101,12 +123,6 @@ const vimeo = {
       ...hashParam,
       ...frameParams,
     });
-
-
-    // Get from <div> if needed
-    if (is.empty(source)) {
-      source = player.media.getAttribute(player.config.attributes.embed.id);
-    }
 
     const id = parseId(source);
     // Build an iframe


### PR DESCRIPTION
### Link to related issue (if applicable)

https://github.com/sampotts/plyr/issues/2321

### Summary of proposed changes

As Vimeo now expects a given hash as a url-parameter `?h={hash}` for _newly uploaded private videos_, I added some code for basic checking whether the given src-url contains the private hash, extracting it and adding it as a parameter to the iframe, if needed.
'Basic' as in, you might want to make this more sophisticated: currently I just strip the src-url, but adding a separate option for vimeo-src or something might be preferred. Also this might be put into some checks whether the user has a business-/pro-account, as otherwise he can't have private videos anyway.

I can change this PR accordingly, if you need me to :)
This currently works as a workaround for us, as you have to do nothing different when using plyr (don't have to split the embed-url by yourself etc.)