### PR TITLE
pass this context to captions.setup

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -958,7 +958,7 @@ class Plyr {
    */
   set currentTrack(input) {
     captions.set.call(this, input, false);
-    captions.setup();
+    captions.setup.call(this);
   }
 
   /**


### PR DESCRIPTION
### Link to related issue (if applicable)
PR introducing the exception: https://github.com/sampotts/plyr/pull/2261

### Summary of proposed changes
Passes correct context for 'this' into captions.setup to fix 'Uncaught TypeError: Cannot read properties of undefined' at https://github.com/sampotts/plyr/blob/1c33098c42ba19ad0db3e44a9402bfa10d3f3726/src/js/captions.js#L29

This error occurs when switching the caption language (can be seen in the demo at https://plyr.io/ if you change your caption language).

