### PR TITLE
modify vimeo parseHash to use non-named capture groups

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -35,12 +35,12 @@ function parseHash(url) {
    *  - [https://player.]vimeo.com/video/{id}?h={hash}[&params]
    *  - [https://player.]vimeo.com/video/{id}?[params]&h={hash}
    *  - video/{id}/{hash}
-   * If matched, the hash is available in the named group `hash`
+   * If matched, the hash is available in capture group 4
    */
-  const regex = /^.*(?:vimeo.com\/|video\/)(?:\d+)(?:\?.*&*h=|\/)+(?<hash>[\d,a-f]+)/;
+  const regex = /^.*(vimeo.com\/|video\/)(\d+)(\?.*&*h=|\/)+([\d,a-f]+)/;
   const found = url.match(regex);
 
-  return found ? found.groups.hash : null;
+  return found && found.length === 5 ? found[4] : null;
 }
 
 // Set playback state and trigger change (only on actual change)


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/2396

### Summary of proposed changes
First of all, thanks for all the great work on Plyr!

Plyr 3.6.9 introduced a new function `parseHash` in `plugins/vimeo.js` which uses named regexp groups.
Unfortunately, support for this feature in Firefox was only added in version 78 (see https://caniuse.com/mdn-javascript_builtins_regexp_named_capture_groups).
I'm still seeing quite a few users using this version, and they fail to load the video player because the used regex causes a Syntax Error. I worked around this by lazy-loading Plyr in a separate file and falling back to the native video player, but that's not ideal.

This PR changes the regex to use "legacy" capture groups in order to resolve this issue.
I do understand that this a bit annoying, as named capture groups are indeed much nicer to use than standard capture groups, but unfortunately it is not possible to Polyfill regex features. Given that the mentioned Firefox versions is less than 2 years old, I think it is reasonable to still support it.

I tested the new regex with the following strings:

```javascript
parseHash('https://player.vimeo.com/video/1234/123abc?a=b'); // 123abc
parseHash('https://player.vimeo.com/video/1234/123abc'); // 123abc
parseHash('https://vimeo.com/video/1234/123abc?a=b'); // 123abc
parseHash('https://vimeo.com/video/1234/123abc'); // 123abc

parseHash('https://player.vimeo.com/video/1234?h=123abc&a=b'); // 123abc
parseHash('https://player.vimeo.com/video/1234?h=123abc'); // 123abc
parseHash('https://vimeo.com/video/1234?h=123abc&a=b'); // 123abc
parseHash('https://vimeo.com/video/1234?h=123abc'); // 123abc

parseHash('https://player.vimeo.com/video/1234?a=b&h=123abc'); // 123abc
parseHash('https://player.vimeo.com/video/1234?a=b&c=d&h=123abc'); // 123abc
parseHash('https://vimeo.com/video/1234?a=b&h=123abc'); // 123abc
parseHash('https://vimeo.com/video/1234?a=b&c=d&h=123abc'); // 123abc

parseHash('video/1234/123abc'); // 123abc
```