### PR TITLE
Fix 'this' while switching subtitle tracks

### DIFF
--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -958,7 +958,7 @@ class Plyr {
    */
   set currentTrack(input) {
     captions.set.call(this, input, false);
-    captions.setup();
+    captions.setup.call(this);
   }
 
   /**


### PR DESCRIPTION
When you switch a subtitle track you'll get

`TypeError: Cannot read properties of undefined (reading 'ui')` in `captions.js`'s `captions.setup`,

Because `captions.setup` is being called without proper `this` binding.

![image](https://user-images.githubusercontent.com/4316558/157271315-2155984e-92e5-43e8-8508-77bf5cb71361.png)


### Link to related issue (if applicable)

### Summary of proposed changes

Bind this while calling captions.setup