### PR TITLE
Added configurable property to elements for re-use

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1716,6 +1716,7 @@ const controls = {
       const addProperty = (button) => {
         const className = this.config.classNames.controlPressed;
         Object.defineProperty(button, 'pressed', {
+          configurable: true,
           enumerable: true,
           get() {
             return hasClass(button, className);


### PR DESCRIPTION
Apparently, if you make a Plyr instance with custom elements. **Plyr declares some of the properties in the element as non-configurable**. So, if you want to **destroy that Plyr instance** and instantiate it again, **Javascript complains of redefining a non-configurable property 'pressed'.** This happens only when the custom elements are an object and not a strings btw.

### Link to related issue (if applicable)

No, issue precisely about this was opened.

### Summary of proposed changes

One line was added to make 'pressed' property configurable.
