### PR TITLE
Make isFunction safer in case of global pollution of Function class

### DIFF
--- a/src/js/utils/is.js
+++ b/src/js/utils/is.js
@@ -9,7 +9,7 @@ const isObject = (input) => getConstructor(input) === Object;
 const isNumber = (input) => getConstructor(input) === Number && !Number.isNaN(input);
 const isString = (input) => getConstructor(input) === String;
 const isBoolean = (input) => getConstructor(input) === Boolean;
-const isFunction = (input) => getConstructor(input) === Function;
+const isFunction = (input) => typeof getConstructor(input) === 'function';
 const isArray = (input) => Array.isArray(input);
 const isWeakMap = (input) => instanceOf(input, WeakMap);
 const isNodeList = (input) => instanceOf(input, NodeList);


### PR DESCRIPTION
### Summary of proposed changes
Our company uses a 3rd-party security service that was wrapping the `Function` class in a `Proxy` and that made the comparison fail, so no videos would start