### PR TITLE
fix: allow unlisted vimeo video urls when loading using data attributes (#2504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Or the `<div>` non progressively enhanced method:
 <div id="player" data-plyr-provider="vimeo" data-plyr-embed-id="76979871"></div>
 ```
 
+_Note_: The `data-plyr-embed-id` can either be the video ID or URL for the media.
+
 ## JavaScript
 
 You can use Plyr as an ES6 module as follows:

--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -24,8 +24,10 @@ function parseId(url) {
     return url;
   }
 
-  const regex = /^.*(vimeo.com\/|video\/)(\d+).*/;
-  return url.match(regex) ? RegExp.$2 : url;
+  const regex = /^(.*vimeo.com\/|.*video\/)?(\d+).*/;
+  const found = url.match(regex);
+
+  return !found ? url : found[found.length - 1];
 }
 
 // Try to extract a hash for private videos from the URL
@@ -35,12 +37,13 @@ function parseHash(url) {
    *  - [https://player.]vimeo.com/video/{id}?h={hash}[&params]
    *  - [https://player.]vimeo.com/video/{id}?[params]&h={hash}
    *  - video/{id}/{hash}
-   * If matched, the hash is available in capture group 4
+   *  - {id}/{hash}
+   * If matched, the hash is available in the captured group
    */
-  const regex = /^.*(vimeo.com\/|video\/)(\d+)(\?.*&*h=|\/)+([\d,a-f]+)/;
+  const regex = /^(.*vimeo.com\/|.*video\/)?(\d+)(\?.*&*h=|\/)+([\d,a-f]+)/;
   const found = url.match(regex);
 
-  return found && found.length === 5 ? found[4] : null;
+  return !found ? url : found[found.length - 1];
 }
 
 // Set playback state and trigger change (only on actual change)
@@ -94,6 +97,11 @@ const vimeo = {
       source = player.media.getAttribute(player.config.attributes.embed.id);
       // hash can also be set as attribute on the <div>
       hash = player.media.getAttribute(player.config.attributes.embed.hash);
+      // In case hash is not explicitly set as attribute we try to parse it from the id attribute
+      if (!hash) {
+        hash = parseHash(source);
+        alert(hash);
+      }
     } else {
       hash = parseHash(source);
     }


### PR DESCRIPTION
### Link to related issue (if applicable)
#2504 

Also see #2322 which fixed the issue, except for the case when data attributes are used.
Also this old ticket #593 can probably be closed with this fix.

### Summary of proposed changes
This allows us to use URLs of unlisted Vimeo videos in the data-plyr-embed-id data attribute. Currently, data-plyr-embed-id does work with full vimeo URLs like this
`<div id="player" data-plyr-provider="vimeo" data-plyr-embed-id="https://vimeo.com/40648169"></div>`
but it doesn't work when the URL contains an additional hash (unlisted video):
`<div id="player" data-plyr-provider="vimeo" data-plyr-embed-id="https://vimeo.com/729894358/7767dc808d"></div>`

I found an undocumented data attribute called data-plyr-embed-hash which can be used to set the hash separately. But if we allow setting full URLs using the data-plyr-embed-id attribute, I would expect to be able to pass the URL including the hash to this attribute without having to care about the privacy settings of the video myself.