### PR TITLE
docs: replace example video ID with one that still works

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ player.source = {
   type: 'video',
   sources: [
     {
-      src: '143418951',
+      src: '76979871',
       provider: 'vimeo',
     },
   ],


### PR DESCRIPTION
### Description
The old ID [doesn't work](https://vimeo.com/143418951) anymore, so I replaced it with another one you used [elsewhere](https://github.com/sampotts/plyr/blame/master/README.md#L102) in the README, which does [work](https://vimeo.com/76979871).