### PR TITLE
Fix for calc() in newer Dart Sass versions

### DIFF
--- a/src/sass/components/menus.scss
+++ b/src/sass/components/menus.scss
@@ -192,7 +192,7 @@
       align-items: center;
       display: flex;
       margin-left: auto;
-      margin-right: calc((#{$plyr-control-padding} - 2) * -1);
+      margin-right: calc((#{$plyr-control-padding} - 2px) * -1);
       overflow: hidden;
       padding-left: calc(#{$plyr-control-padding} * 3.5);
       pointer-events: none;


### PR DESCRIPTION
### Link to related issue (if applicable)

[Issue 2323](https://github.com/sampotts/plyr/issues/2323) 

### Summary of proposed changes

Several people (including myself) encountered a bug as Dart Sass became more strict with its `calc()` function. This specific line without a `px` unit breaks compilation.