### PR TITLE
Improve accessibility on control buttons with aria-pressed

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -1715,6 +1715,8 @@ const controls = {
     if (!is.empty(this.elements.buttons)) {
       const addProperty = (button) => {
         const className = this.config.classNames.controlPressed;
+        button.setAttribute('aria-pressed', 'false');
+
         Object.defineProperty(button, 'pressed', {
           enumerable: true,
           get() {
@@ -1722,6 +1724,7 @@ const controls = {
           },
           set(pressed = false) {
             toggleClass(button, className, pressed);
+            button.setAttribute('aria-pressed', pressed ? 'true' : 'false');
           },
         });
       };


### PR DESCRIPTION
Improve accessibility by adding `aria-pressed` attribute to control buttons and sync with together with the `pressed` attribute.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed