### PR TITLE
navigator.platform is deprecated

### DIFF
--- a/src/js/utils/browser.js
+++ b/src/js/utils/browser.js
@@ -5,12 +5,11 @@
 
 const browser = {
   isIE: Boolean(window.document.documentMode),
-  isEdge: window.navigator.userAgent.includes('Edge'),
-  isWebkit: 'WebkitAppearance' in document.documentElement.style && !/Edge/.test(navigator.userAgent),
-  isIPhone: /(iPhone|iPod)/gi.test(navigator.platform),
+  isEdge: /Edge/g.test(navigator.userAgent),
+  isWebkit: 'WebkitAppearance' in document.documentElement.style && !/Edge/g.test(navigator.userAgent),
+  isIPhone: /iPhone|iPod/gi.test(navigator.userAgent) && navigator.maxTouchPoints > 1,
   isIos:
-    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) ||
-    /(iPad|iPhone|iPod)/gi.test(navigator.platform),
+    /iPad|iPhone|iPod/gi.test(navigator.userAgent) && navigator.maxTouchPoints > 1
 };
 
 export default browser;


### PR DESCRIPTION
I'm submitting a little update for browser detection:

1. `navigator.platform` is deprecated - it's prefered to use `navigator.userAgent` https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
2. No need for the brackets in the RegEx - you can test this on https://regex101.com

And that's about it. Maybe I missed the point, do let me know! ❤️