### PR TITLE
i18n: Make captions autodetect text direction

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -47,6 +47,7 @@ const captions = {
     // Inject the container
     if (!is.element(this.elements.captions)) {
       this.elements.captions = createElement('div', getAttributesFromSelector(this.config.selectors.captions));
+      this.elements.captions.setAttribute('dir', 'auto');
 
       insertAfter(this.elements.captions, this.elements.wrapper);
     }


### PR DESCRIPTION
This uses browser mechanism for detecting appropiate direction for text, dir=auto.

### Link to related issue (if applicable)
Fixes #2043

### Summary of proposed changes
This uses `dir="auto"` so subtitles written in RTL scripts (Persian, Arabic, Hebrew and etc) will have a better direction using plyr.

Use of dir=auto in such scenarios are very common, for example see this very page source and find `dir=auto` that is used all over the user content to enhance the display of user text that can be in different language even in GitHub. Years ago I added the thing in Gitlab also [here](https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/6296) years ago before GitHub's adoption with the improvement and now as plyr was used by someone that needed this fix am adding the the improvement here also.

<img width="457" alt="image" src="https://user-images.githubusercontent.com/833473/194726222-a228236c-b898-4ca8-9458-c14f75e7581f.png">
