### PR TITLE
fix tooltip seek render bug

### DIFF
--- a/src/sass/components/progress.scss
+++ b/src/sass/components/progress.scss
@@ -27,7 +27,7 @@ $plyr-progress-offset: $plyr-range-thumb-height;
     left: 0;
     max-width: 120px;
     overflow-wrap: break-word;
-    white-space: normal;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
`white-space: normal; `

<img width="584" alt="Screen Shot 2022-10-23 at 5 53 48 PM" src="https://user-images.githubusercontent.com/28949554/197422321-54b7aba0-eaea-4848-9e1c-d8ad87e244bd.png">

`white-space: nowrap;`
<img width="594" alt="Screen Shot 2022-10-23 at 5 53 17 PM" src="https://user-images.githubusercontent.com/28949554/197422340-7d4ee29a-1cde-42ae-a936-12301f6596ec.png">

