### PR TITLE
Fixed event key with space

### DIFF
--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -404,7 +404,7 @@ const controls = {
       'keydown keyup',
       (event) => {
         // We only care about space and ⬆️ ⬇️️ ➡️
-        if (!['Space', 'ArrowUp', 'ArrowDown', 'ArrowRight'].includes(event.key)) {
+        if (![' ', 'ArrowUp', 'ArrowDown', 'ArrowRight'].includes(event.key)) {
           return;
         }
 
@@ -420,12 +420,12 @@ const controls = {
         const isRadioButton = matches(menuItem, '[role="menuitemradio"]');
 
         // Show the respective menu
-        if (!isRadioButton && ['Space', 'ArrowRight'].includes(event.key)) {
+        if (!isRadioButton && [' ', 'ArrowRight'].includes(event.key)) {
           controls.showMenuPanel.call(this, type, true);
         } else {
           let target;
 
-          if (event.key !== 'Space') {
+          if (event.key !== ' ') {
             if (event.key === 'ArrowDown' || (isRadioButton && event.key === 'ArrowRight')) {
               target = menuItem.nextElementSibling;
 
@@ -504,7 +504,7 @@ const controls = {
       menuItem,
       'click keyup',
       (event) => {
-        if (is.keyboardEvent(event) && event.key !== 'Space') {
+        if (is.keyboardEvent(event) && event.key !== ' ') {
           return;
         }
 

--- a/src/js/listeners.js
+++ b/src/js/listeners.js
@@ -65,14 +65,14 @@ class Listeners {
           return;
         }
 
-        if (event.key === 'Space' && matches(focused, 'button, [role^="menuitem"]')) {
+        if (event.key === ' ' && matches(focused, 'button, [role^="menuitem"]')) {
           return;
         }
       }
 
       // Which keys should we prevent default
       const preventDefault = [
-        'Space',
+        ' ',
         'ArrowLeft',
         'ArrowUp',
         'ArrowRight',
@@ -118,7 +118,7 @@ class Listeners {
           }
           break;
 
-        case 'Space':
+        case ' ':
         case 'k':
           if (!repeat) {
             silencePromise(player.togglePlay());
@@ -663,7 +663,7 @@ class Listeners {
       elements.buttons.settings,
       'keyup',
       (event) => {
-        if (!['Space', 'Enter'].includes(event.key)) {
+        if (![' ', 'Enter'].includes(event.key)) {
           return;
         }
 


### PR DESCRIPTION
### Link to related issue (if applicable)
https://github.com/sampotts/plyr/issues/2490

### Summary of proposed changes
The library switched from `event.keyCode` to `event.key` for listeners here:  https://github.com/sampotts/plyr/releases/tag/v3.7.1

But the space bar wasn't working because the `event.key` for spacebar is an empty space string `" "`. See the [mdn reference](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#whitespace_keys).

Thank you for such an asewome library! :smile: 