### PR TITLE
Call preview-thumbnails `listeners()` function on load

### DIFF
--- a/src/js/plugins/preview-thumbnails.js
+++ b/src/js/plugins/preview-thumbnails.js
@@ -123,6 +123,9 @@ class PreviewThumbnails {
       // Check to see if thumb container size was specified manually in CSS
       this.determineContainerAutoSizing();
 
+      // Set up listeners
+      this.listeners();
+
       this.loaded = true;
     });
   };


### PR DESCRIPTION
### Link to related issue (if applicable)

#2210

### Summary of proposed changes

The `listeners()` function in preview-thumbnails.js was never called, so some functionality was broken. This change calls listeners in the preview-thumbnails load function.
