### PR TITLE
fix(issue #2624): Changing Vimeo.js function used to mute video.

### DIFF
--- a/src/js/plugins/vimeo.js
+++ b/src/js/plugins/vimeo.js
@@ -265,7 +265,7 @@ const vimeo = {
       set(input) {
         const toggle = is.boolean(input) ? input : false;
 
-        player.embed.setVolume(toggle ? 0 : player.config.volume).then(() => {
+        player.embed.setMuted(toggle ? true : player.config.muted).then(() => {
           muted = toggle;
           triggerEvent.call(player, player.media, 'volumechange');
         });


### PR DESCRIPTION
### Link to related issue: https://github.com/sampotts/plyr/issues/2624

### Summary of proposed changes

In the file Vimeo.js, the function responsable to set player muted, uses setVolume(0) but it didn't work on IOS. On Vimeo's API reference, it says "NOTE: Most mobile devices don't support a volume level independent of the system volume. In these cases, this method always returns 1." (https://developer.vimeo.com/player/sdk/reference) , so i changed the function call to setMuted().
