### PR TITLE
Fix #2608: multiple caption tracks for the same language are not available

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -148,8 +148,13 @@ const captions = {
         });
     }
 
+    // Update track by track node if track and language exist
+    if (tracks.includes(currentTrackNode) && languageExists) {
+      captions.setNode.call(this, currentTrackNode);
+      captions.toggle.call(this, active && languageExists);
+    }
     // Update language first time it matches, or if the previous matching track was removed
-    if ((languageExists && this.language !== language) || !tracks.includes(currentTrackNode)) {
+    else if ((languageExists && this.language !== language) || !tracks.includes(currentTrackNode)) {
       captions.setLanguage.call(this, language);
       captions.toggle.call(this, active && languageExists);
     }
@@ -284,6 +289,17 @@ const captions = {
       // If we change the active track while a cue is already displayed we need to update it
       captions.updateCues.call(this);
     }
+  },
+
+  setNode(input, passive = true) {
+    if (!is.track(input)) {
+      this.debug.warn('Invalid track argument', input);
+      return;
+    }
+
+    // Set currentTrack
+    const tracks = captions.getTracks.call(this);
+    captions.set.call(this, tracks.indexOf(input), passive);
   },
 
   // Set captions by language

--- a/src/js/plyr.d.ts
+++ b/src/js/plyr.d.ts
@@ -123,6 +123,11 @@ declare class Plyr {
   currentTrack: number;
 
   /**
+   * Sets the preferred captions node for the player.
+   */
+  nodeTrack: TextTrack;
+
+  /**
    * Gets or sets the preferred captions language for the player. The setter accepts an ISO twoletter language code. Support for the languages is dependent on the captions you include.
    * If your captions don't have any language data, or if you have multiple tracks with the same language, you may want to use currentTrack instead.
    */

--- a/src/js/plyr.js
+++ b/src/js/plyr.js
@@ -969,6 +969,14 @@ class Plyr {
   }
 
   /**
+   * Set the wanted track node for captions
+   * @param {TextTrack} input - Two character ISO language code (e.g. EN, FR, PT, etc)
+   */
+  set nodeTrack(input) {
+    captions.setNode.call(this, input, false);
+  }
+
+  /**
    * Set the wanted language for captions
    * Since tracks can be added later it won't update the actual caption track until there is a matching track
    * @param {String} input - Two character ISO language code (e.g. EN, FR, PT, etc)


### PR DESCRIPTION
### Link to related issue: #2608 

### Summary of proposed changes

### Add
* `captions.setNode` method. This method can set caption track by its node. 

### Change 
* `captions.update` method in `src/js/captions.js:152` firstly checks `currentTrackNode` and calls `setNode` if `currentTrackNode` provided. If captions don't have `currentTrackNode` node, update method calls the `setLanguage` method.

**Demo from issue:**
https://codepen.io/emmitrin/pen/dyjjYKr

**Fixed demo:**
https://codepen.io/gaskeo/pen/abRwjpZ