### PR TITLE
Fix #2799 -- drop recommendation of polyfill.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Plyr supports the last 2 versions of most _modern_ browsers.
 
 ## Polyfills
 
-Plyr uses ES6 which isn't supported in all browsers quite yet. This means some features will need to be polyfilled to be available otherwise you'll run into issues. We've elected to not burden the ~90% of users that do support these features with extra JS and instead leave polyfilling to you to work out based on your needs. The easiest method I've found is to use [polyfill.io](https://polyfill.io) which provides polyfills based on user agent. This is the method the demo uses.
+Plyr uses ES6 which isn't supported in all browsers quite yet. This means some features will need to be polyfilled to be available otherwise you'll run into issues. We've elected to not burden the ~90% of users that do support these features with extra JS and instead leave polyfilling to you to work out based on your needs.
 
 ## Checking for support
 


### PR DESCRIPTION
The polyfill.io domain is shut down due to the reports of a malicious activity
It is better to not recommend/promote it
Refs:
- https://snyk.io/blog/polyfill-supply-chain-attack-js-cdn-assets/
- https://www.sonatype.com/blog/polyfill.io-supply-chain-attack-hits-100000-websites-all-you-need-to-know
