### PR TITLE
Set PIP support based on the Picture in Picture API

### DIFF
--- a/src/js/support.js
+++ b/src/js/support.js
@@ -35,21 +35,8 @@ const support = {
   },
 
   // Picture-in-picture support
-  // Safari & Chrome only currently
   pip: (() => {
-    // Safari
-    // https://developer.apple.com/documentation/webkitjs/adding_picture_in_picture_to_your_safari_media_controls
-    if (is.function(createElement('video').webkitSetPresentationMode)) {
-      return true;
-    }
-
-    // Chrome
-    // https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture
-    if (document.pictureInPictureEnabled && !createElement('video').disablePictureInPicture) {
-      return true;
-    }
-
-    return false;
+    return (document.pictureInPictureEnabled && !createElement('video').disablePictureInPicture);
   })(),
 
   // Airplay support

--- a/src/js/support.js
+++ b/src/js/support.js
@@ -37,13 +37,6 @@ const support = {
   // Picture-in-picture support
   // Safari & Chrome only currently
   pip: (() => {
-    // While iPhone's support picture-in-picture for some apps, seemingly Safari isn't one of them
-    // It will throw the following error when trying to enter picture-in-picture
-    // `NotSupportedError: The Picture-in-Picture mode is not supported.`
-    if (browser.isIPhone) {
-      return false;
-    }
-
     // Safari
     // https://developer.apple.com/documentation/webkitjs/adding_picture_in_picture_to_your_safari_media_controls
     if (is.function(createElement('video').webkitSetPresentationMode)) {


### PR DESCRIPTION
### Summary of proposed changes
Previously, picture in picture support was explicitly disabled on iPhones,and used the webkit specific APIs for Safari in general.
    
Safari (both mobile and desktop) has supported the Picture in Picture API since September 15, 2020 (https://caniuse.com/picture-in-picture) so there's no need to use the webkit API.
    
Additionally, picture in picture support appears to work on iPhones with this API, so the check is no longer necessary.
    
#### Tested on:
    
- iPhone 14 (physical device)
- iPad 9th gen (browserstack.com)
    
#### Negative tests
    
- iPhone 11 (browserstack.com) - predates support but does not raise errorsoes not raise errors