### PR TITLE
add Mux as an example in the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-| 🎉  | [Plyr is merging into Vidstack](https://github.com/sampotts/plyr/issues/2408) | 🎉  |
-| :-: | :---------------------------------------------------------------------------: | :-- |
-
 Plyr is a simple, lightweight, accessible and customizable HTML5, YouTube and Vimeo media player that supports [_modern_](#browser-support) browsers.
 
-[Checkout the demo](https://plyr.io) - [Donate](#donate) - [Slack](https://bit.ly/plyr--chat)
+[Checkout the demo](https://plyr.io) - [Donate](#donate) - [Slack](https://bit.ly/plyr--chat) - [Video hosting](https://mux.com?ref=plyr-github)
 
 [![npm version](https://badge.fury.io/js/plyr.svg)](https://badge.fury.io/js/plyr) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/sampotts/plyr) [![Financial Contributors on Open Collective](https://opencollective.com/plyr/all/badge.svg?label=financial+contributors)](https://opencollective.com/plyr)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -84,6 +84,19 @@
             </svg>
             Audio</button
           >,
+          <button type="button" class="link" data-source="mux">
+            <svg class="icon" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <g clip-path="url(#clip0_5607_90730)">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M16 0H0V16H16V0ZM11.4398 2.43862C11.8687 2.00974 12.5138 1.88158 13.0742 2.11366C13.6346 2.34574 14.0001 2.8927 14.0001 3.49918V12.4997C14.0001 13.3279 13.3286 13.9995 12.5004 13.9995C11.6722 13.9995 11.0007 13.3279 11.0007 12.4997V7.11959L9.06054 9.05976C8.47495 9.64536 7.52529 9.64536 6.9397 9.05976L4.99958 7.11959V12.4997C4.99958 13.3279 4.32807 13.9995 3.49985 13.9995C2.67162 13.9995 2.00012 13.3279 2.00012 12.4997V3.49918C2.00012 2.89246 2.36539 2.34574 2.92578 2.11366C3.48617 1.88158 4.13127 2.00974 4.56015 2.43862L8 5.87855L11.4398 2.43862ZM11.7564 12.4999C11.7564 12.9108 12.0895 13.2439 12.5004 13.2439C12.9113 13.2439 13.2444 12.9108 13.2444 12.4999C13.2444 12.089 12.9113 11.7559 12.5004 11.7559C12.0895 11.7559 11.7564 12.089 11.7564 12.4999Z" fill="#00b2ff"/>
+              </g>
+              <defs>
+              <clipPath id="clip0_5607_90730">
+              <rect width="16" height="16" fill="white"/>
+              </clipPath>
+              </defs>
+            </svg>
+            Mux
+          </button>,
           <button type="button" class="link" data-source="youtube">
             <svg class="icon" role="presentation">
               <title>YouTube</title>
@@ -124,6 +137,9 @@
             </svg>
             Download on GitHub
           </a>
+          <div class="cta-mux">
+            Looking for video hosting? Check out <a href="https://mux.com?ref=plyr">Mux</a>.
+          </div>
         </div>
       </header>
       <main>
@@ -170,6 +186,15 @@
             <!-- Fallback for browsers that don't support the <video> element -->
             <a href="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4" download>Download</a>
           </video>
+          <video
+            controls
+            crossorigin
+            playsinline
+            data-poster="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.jpg"
+            id="player-hls"
+            hidden
+          >
+          </video>
         </div>
 
         <ul>
@@ -187,7 +212,7 @@
                 class="link"
                 >View From A Blue Moon</a
               >
-              &copy; Brainfarm
+              <span>&copy; Brainfarm</span>
             </small>
           </li>
           <li class="plyr__cite plyr__cite--audio" hidden>
@@ -201,7 +226,24 @@
               <a href="http://www.kishibashi.com/" target="_blank" class="link"
                 >Kishi Bashi &ndash; &ldquo;It All Began With A Burst&rdquo;</a
               >
-              &copy; Kishi Bashi
+              <span>&copy; Kilshi Bashi</span>
+            </small>
+          </li>
+          <li class="plyr__cite plyr__cite--mux" hidden>
+            <small>
+              <a
+                href="https://itunes.apple.com/au/movie/view-from-a-blue-moon/id1041586323"
+                target="_blank"
+                class="link"
+                >View From A Blue Moon</a
+              >
+              <span>&copy; Brainfarm</span>
+              <span>on</span>
+              <svg class="icon">
+                <title>Mux</title>
+                <svg width="100%" height="100%" viewBox="0 0 1600 500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><g id="Layer-1" serif:id="Layer 1"><path d="M994.287,93.486c-17.121,-0 -31,-13.879 -31,-31c0,-17.121 13.879,-31 31,-31c17.121,-0 31,13.879 31,31c0,17.121 -13.879,31 -31,31m0,-93.486c-34.509,-0 -62.484,27.976 -62.484,62.486l0,187.511c0,68.943 -56.09,125.033 -125.032,125.033c-68.942,-0 -125.03,-56.09 -125.03,-125.033l0,-187.511c0,-34.51 -27.976,-62.486 -62.485,-62.486c-34.509,-0 -62.484,27.976 -62.484,62.486l0,187.511c0,137.853 112.149,250.003 249.999,250.003c137.851,-0 250.001,-112.15 250.001,-250.003l0,-187.511c0,-34.51 -27.976,-62.486 -62.485,-62.486" style="fill-rule:nonzero;"/><path d="M1537.51,468.511c-17.121,-0 -31,-13.879 -31,-31c0,-17.121 13.879,-31 31,-31c17.121,-0 31,13.879 31,31c0,17.121 -13.879,31 -31,31m-275.883,-218.509l-143.33,143.329c-24.402,24.402 -24.402,63.966 0,88.368c24.402,24.402 63.967,24.402 88.369,-0l143.33,-143.329l143.328,143.329c24.402,24.4 63.967,24.402 88.369,-0c24.403,-24.402 24.403,-63.966 0.001,-88.368l-143.33,-143.329l0.001,-0.004l143.329,-143.329c24.402,-24.402 24.402,-63.965 0,-88.367c-24.402,-24.402 -63.967,-24.402 -88.369,-0l-143.329,143.328l-143.329,-143.328c-24.402,-24.401 -63.967,-24.402 -88.369,-0c-24.402,24.402 -24.402,63.965 0,88.367l143.329,143.329l0,0.004Z" style="fill-rule:nonzero;"/><path d="M437.511,468.521c-17.121,-0 -31,-13.879 -31,-31c0,-17.121 13.879,-31 31,-31c17.121,-0 31,13.879 31,31c0,17.121 -13.879,31 -31,31m23.915,-463.762c-23.348,-9.672 -50.226,-4.327 -68.096,13.544l-143.331,143.329l-143.33,-143.329c-17.871,-17.871 -44.747,-23.216 -68.096,-13.544c-23.349,9.671 -38.574,32.455 -38.574,57.729l0,375.026c0,34.51 27.977,62.486 62.487,62.486c34.51,-0 62.486,-27.976 62.486,-62.486l0,-224.173l80.843,80.844c24.404,24.402 63.965,24.402 88.369,-0l80.843,-80.844l0,224.173c0,34.51 27.976,62.486 62.486,62.486c34.51,-0 62.486,-27.976 62.486,-62.486l0,-375.026c0,-25.274 -15.224,-48.058 -38.573,-57.729" style="fill-rule:nonzero;"/></g>
+                </svg>
+              </svg>
             </small>
           </li>
           <li class="plyr__cite plyr__cite--youtube" hidden>
@@ -253,15 +295,16 @@
       <p>
         If you think Plyr's good,
         <a
-          href="https://twitter.com/intent/tweet?text=A+simple+HTML5+media+player+with+custom+controls+and+WebVTT+captions.&amp;url=http%3A%2F%2Fplyr.io&amp;via=Sam_Potts"
+          href="https://x.com/intent/tweet?text=A+simple+HTML5+media+player+with+custom+controls+and+WebVTT+captions.&amp;url=http%3A%2F%2Fplyr.io&amp;via=Sam_Potts"
           target="_blank"
           class="link js-shr"
-          >tweet it</a
+          >share it on Twitter</a
         >
         👍
       </p>
     </aside>
 
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
     <script src="dist/demo.js" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/demo/src/js/demo.js
+++ b/demo/src/js/demo.js
@@ -25,6 +25,10 @@ import sources from './sources';
     });
   }
 
+  function createPlyrInstance (selector, config) {
+    return new Plyr(selector, config);
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     const selector = '#player';
 
@@ -39,7 +43,7 @@ import sources from './sources';
     });
 
     // Setup the player
-    const player = new Plyr(selector, {
+    const player = createPlyrInstance(selector, {
       debug: true,
       title: 'View From A Blue Moon',
       iconUrl: 'dist/demo.svg',
@@ -104,6 +108,46 @@ import sources from './sources';
     let currentType = window.location.hash.substring(1);
     const hasInitialType = currentType.length;
 
+    /* The audio player needs the container element shown/hidden
+     * The video player needs the media element shown/hidden
+     * */
+    function showHlsPlayer() {
+      if (window.player.elements && window.player.elements.container) {
+        window.player.elements.container.hidden = true;
+        if (window.player.media) {
+          window.player.media.hidden = true;
+          window.player.pause();
+        }
+      }
+      if (window.playerHls.elements && window.playerHls.elements.container) {
+        window.playerHls.elements.container.hidden = false;
+        if (window.playerHls.media) {
+          window.playerHls.media.hidden = false;
+        }
+      }
+    }
+
+    /* The audio player needs the container element shown/hidden
+     * The video player needs the media element shown/hidden
+     * */
+    function showMainPlayer() {
+      if (window.player.elements && window.player.elements.container) {
+        window.player.elements.container.hidden = false;
+        window.player.hidden = false;
+        if (window.player.media) {
+          window.player.media.hidden = false;
+          window.player.media.pause();
+        }
+      }
+      if (window.playerHls.elements && window.playerHls.elements.container) {
+        window.playerHls.elements.container.hidden = true;
+        window.playerHls.hidden = true;
+        if (window.playerHls.media) {
+          window.playerHls.media.hidden = true;
+        }
+      }
+    }
+
     function render(type) {
       // Remove active classes
       Array.from(buttons).forEach((button) => button.parentElement.classList.toggle('active', false));
@@ -118,6 +162,12 @@ import sources from './sources';
       });
 
       document.querySelector(`.plyr__cite--${type}`).hidden = false;
+
+      if (type === "mux") {
+        showHlsPlayer();
+      } else {
+        showMainPlayer();
+      }
     }
 
     // Set a new source
@@ -127,12 +177,26 @@ import sources from './sources';
         return;
       }
 
-      // Set the new source
-      player.source = sources[type];
-
+      const sourceConfig = sources[type];
+      const hlsSource = sourceConfig.hls_source;
+      if (hlsSource) {
+        window.playerHls = createPlyrInstance("#player-hls", sourceConfig);
+        const video = playerHls.media;
+        if (Hls.isSupported()) {
+          var hls = new Hls();
+          hls.loadSource(hlsSource);
+          hls.attachMedia(video);
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+          video.src = videoSrc;
+        }
+      } else {
+        if (window.playerHls) {
+          window.playerHls.destroy();
+        }
+        player.source = sourceConfig;
+      }
       // Set the current type for next time
       currentType = type;
-
       render(type);
     }
 

--- a/demo/src/js/sources.js
+++ b/demo/src/js/sources.js
@@ -1,4 +1,14 @@
 const sources = {
+  mux: {
+    type: 'video',
+    title: 'View From A Blue Moon',
+    hls_source: 'https://stream.mux.com/lyrKpPcGfqyzeI00jZAfW6MvP6GNPrkML.m3u8',
+    poster: 'https://image.mux.com/lyrKpPcGfqyzeI00jZAfW6MvP6GNPrkML/thumbnail.jpg',
+    previewThumbnails: {
+      enabled: true,
+      src: 'https://image.mux.com/lyrKpPcGfqyzeI00jZAfW6MvP6GNPrkML/storyboard.vtt'
+    },
+  },
   video: {
     type: 'video',
     title: 'View From A Blue Moon',

--- a/demo/src/sass/components/header.scss
+++ b/demo/src/sass/components/header.scss
@@ -17,6 +17,16 @@ header {
     margin-top: ($spacing-base * 1.5);
   }
 
+  .cta-mux {
+    margin-top: $spacing-base;
+
+    a {
+      border-bottom: 1px solid $color-link;
+      color: $color-link;
+      text-decoration: none;
+    }
+  }
+
   @media only screen and (min-width: $screen-md) {
     margin-right: ($spacing-base * 3);
     max-width: 360px;

--- a/demo/src/sass/components/players.scss
+++ b/demo/src/sass/components/players.scss
@@ -35,7 +35,21 @@
 .plyr__cite {
   color: $color-gray-500;
 
+  small {
+    display: flex;
+    justify-content: center;
+  }
+
+  small > :not(:last-child) {
+    margin-right: 10px;
+  }
+
   .icon {
     margin-right: math.div($spacing-base, 6);
   }
+}
+
+.plyr__cite--mux .icon {
+  height: 20px;
+  width: 53px;
 }


### PR DESCRIPTION
- [x] add Mux as an example in the demo (after HTML5 video/audio)
- [x] Also added a link to mux.com for folks seeking video hosting
- [x] Added a small line linking to Mux for video hosting in the README
- [x] Removed vidstack callout in the README

A few complications in the demo.js code to call out:

- Since Mux is an HLS source, this required loading hls.js which I am doing from the CDN at the bottom of the demo.html file
- Re-using the media element for an HLS source and then toggling back to a non-hls source did not work cleanly, so in order to do this I needed to add 2 elements on the page, a `#player` and a `#player-hls`
- There's a bit of hacky-code to show/hide the right player (and pausing the underlying media element when hiding
- I found that for Plyr instances of type `"video"`, you could set player.media.hidden = true and that would hide the player
- But for Plyr instances of type `"audio"`, that didn't work, so it required setting `hidden` on the `player.elements.container`

Testing

- Everything seems to be working, I tried loading in different states and toggling between the different options and things are switching as expected