### PR TITLE
fix: remove unused --plyr-font-smoothing variable and set default smoothing

### DIFF
--- a/src/sass/lib/mixins.scss
+++ b/src/sass/lib/mixins.scss
@@ -11,13 +11,15 @@
 
 // Font smoothing
 // ---------------------------------------
-@mixin plyr-font-smoothing($mode: true) {
-  @if $mode {
+@mixin plyr-font-smoothing($mode: $plyr-font-smoothing) {
+  @if $mode == true {
+    -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    -webkit-font-smoothing: $plyr-font-smoothing; // Used the correct Var
+  } @else {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
   }
 }
-
 // <input type="range"> styling
 // ---------------------------------------
 @mixin plyr-range-track() {

--- a/src/sass/lib/mixins.scss
+++ b/src/sass/lib/mixins.scss
@@ -14,7 +14,7 @@
 @mixin plyr-font-smoothing($mode: true) {
   @if $mode {
     -moz-osx-font-smoothing: grayscale;
-    -webkit-font-smoothing: antialiased;
+    -webkit-font-smoothing: $plyr-font-smoothing; // Used the correct Var
   }
 }
 

--- a/src/sass/settings/type.scss
+++ b/src/sass/settings/type.scss
@@ -13,4 +13,4 @@ $plyr-font-size-badge: var(--plyr-font-size-badge, 9px) !default;
 $plyr-font-weight-regular: var(--plyr-font-weight-regular, 400) !default;
 $plyr-font-weight-bold: var(--plyr-font-weight-bold, 600) !default;
 $plyr-line-height: var(--plyr-line-height, 1.7) !default;
-$plyr-font-smoothing: var(--plyr-font-smoothing, false) !default;
+$plyr-font-smoothing: antialiased !default;

--- a/src/sass/settings/type.scss
+++ b/src/sass/settings/type.scss
@@ -13,4 +13,4 @@ $plyr-font-size-badge: var(--plyr-font-size-badge, 9px) !default;
 $plyr-font-weight-regular: var(--plyr-font-weight-regular, 400) !default;
 $plyr-font-weight-bold: var(--plyr-font-weight-bold, 600) !default;
 $plyr-line-height: var(--plyr-line-height, 1.7) !default;
-$plyr-font-smoothing: antialiased !default;
+$plyr-font-smoothing: var(--plyr-font-smoothing, true) !default;


### PR DESCRIPTION
### Link to related issue (if applicable)
Fixes #2873
### Summary of proposed changes
- Kept the SCSS variable $plyr-font-smoothing and CSS custom property --plyr-font-smoothing so users can override it.
- Updated the plyr-font-smoothing mixin to respect the $mode argument, ensuring that explicit calls like @include plyr-font-smoothing(true) work correctly.
- Default font smoothing is now true (antialiased for webkit, grayscale for Firefox).
- Ensures font smoothing now applies consistently across all elements.
