### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "hyrious.import-cost",
-    "pflannery.vscode-versionlens",
+    "legalfina.npm-version-lens",
     "streetsidesoftware.code-spell-checker",
     "DavidAnson.vscode-markdownlint"
   ]


### PR DESCRIPTION
Replace outdated/alternative npm version extensions with legalfina.npm-version-lens.

npm-version-lens provides:
- Color-coded version indicators in package.json
- One-click version updates via dropdown
- Inlay hints showing latest versions

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens

### Link to related issue (if applicable)

### Summary of proposed changes
