### PR TITLE
fix(captions): case-insensitive language matching + keep selected track

### DIFF
--- a/src/js/captions.js
+++ b/src/js/captions.js
@@ -120,7 +120,7 @@ const captions = {
     const tracks = captions.getTracks.call(this, true);
     // Get the wanted language
     const { active, language, meta, currentTrackNode } = this.captions;
-    const languageExists = Boolean(tracks.find(track => track.language === language));
+    const languageExists = Boolean(tracks.find(track => (track.language || '').toLowerCase() === language));
 
     // Handle tracks (add event listener and "pseudo"-default)
     if (this.isHTML5 && this.isVideo) {
@@ -300,7 +300,17 @@ const captions = {
 
     // Set currentTrack
     const tracks = captions.getTracks.call(this);
-    const track = captions.findTrack.call(this, [language]);
+    // Keep the currently selected track if it still matches the requested
+    // language. This lets users switch between (and stay on) multiple tracks
+    // that share a language — something findTrack alone can't express, as it
+    // always returns the first match for a language.
+    let track = tracks[this.captions.currentTrack];
+    if (track && (track.language || '').toLowerCase() !== language) {
+      track = undefined;
+    }
+    if (!track) {
+      track = captions.findTrack.call(this, [language]);
+    }
     captions.set.call(this, tracks.indexOf(track), passive);
   },
 
@@ -325,7 +335,7 @@ const captions = {
     let track;
 
     languages.every((language) => {
-      track = sorted.find(t => t.language === language);
+      track = sorted.find(t => (t.language || '').toLowerCase() === (language || '').toLowerCase());
       return !track; // Break iteration if there is a match
     });
 


### PR DESCRIPTION
### Link to related issue (if applicable)

### Summary of proposed changes
Two related caption language-matching fixes:

- Match caption tracks case-insensitively. The wanted language is lowercased, but it was compared against the raw track `srclang`, so a track declared as e.g. `srclang="EN"` never matched a preferred language of `en`. Lowercase both sides in `update()` and `findTrack()` (and guard null srclang).

- Keep the currently selected track when several share a language. `setLanguage` always resolved to the *first* track for a language via `findTrack`, so users with multiple same-language tracks could never switch to (or stay on) the others. Prefer the current track when it still matches the requested language, falling back to `findTrack` otherwise.